### PR TITLE
[FEAT] Commit Push

### DIFF
--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -260,8 +260,6 @@ async function handleConflicts(
 
 export async function mergeCommand(prNumber: string): Promise<void> {
   try {
-    log.info(`[DEBUG] 병합 명령어 시작 - PR #${prNumber}`);
-
     const config = await loadConfig();
     if (!config) {
       log.error(t("common.error.github_token"));
@@ -274,45 +272,28 @@ export async function mergeCommand(prNumber: string): Promise<void> {
       process.exit(1);
     }
 
-    log.info(
-      `[DEBUG] 저장소 정보 - 소유자: ${repoInfo.owner}, 저장소: ${repoInfo.repo}`,
-    );
-
     let pr = await getPullRequest({
       owner: repoInfo.owner,
       repo: repoInfo.repo,
       pull_number: parseInt(prNumber, 10),
     });
 
-    log.info(
-      `[DEBUG] PR 정보 로드됨 - 상태: ${pr.state}, 병합됨: ${pr.merged}`,
-    );
-    log.info(
-      `[DEBUG] PR 브랜치 정보 - Head: ${pr.head.ref}, Base: ${pr.base.ref}`,
-    );
-
     // PR 정보 표시
     log.section(t("commands.merge.info.title"));
     log.info(`#${pr.number} ${pr.title}`);
-    log.section("브랜치 정보");
-    log.step(`PR 브랜치: ${pr.head.ref}`);
-    log.step(`대상 브랜치: ${pr.base.ref}`);
-    log.step(`PR 작성자: ${pr.user.login}`);
+    log.section(t("commands.merge.info.branch_info"));
+    log.step(t("commands.merge.info.pr_branch", { branch: pr.head.ref }));
+    log.step(t("commands.merge.info.target_branch", { branch: pr.base.ref }));
+    log.step(t("commands.merge.info.author", { author: pr.user.login }));
 
     // 충돌 확인
     log.section(t("commands.merge.info.checking_conflicts"));
-    log.info("[DEBUG] 충돌 확인 시작");
 
     const conflicts = await getPullRequestConflicts(
       repoInfo.owner,
       repoInfo.repo,
       parseInt(prNumber, 10),
     );
-
-    log.info(`[DEBUG] 충돌 상태: ${conflicts.hasConflicts ? "있음" : "없음"}`);
-    if (conflicts.hasConflicts) {
-      log.info(`[DEBUG] 충돌 파일 수: ${conflicts.conflicts.length}`);
-    }
 
     if (conflicts.hasConflicts) {
       log.warn(t("commands.merge.conflict.found"));
@@ -514,8 +495,6 @@ export async function mergeCommand(prNumber: string): Promise<void> {
       },
     ]);
 
-    log.info(`[DEBUG] 선택된 병합 방법: ${mergeMethod}`);
-
     // 커밋 메시지 입력 (squash 병합의 경우)
     let commitTitle = "";
     let commitMessage = "";
@@ -536,7 +515,6 @@ export async function mergeCommand(prNumber: string): Promise<void> {
       ]);
       commitTitle = title;
       commitMessage = message;
-      log.info("[DEBUG] Squash 커밋 메시지 설정됨");
     }
 
     // 브랜치 삭제 여부 확인
@@ -548,8 +526,6 @@ export async function mergeCommand(prNumber: string): Promise<void> {
         default: true,
       },
     ]);
-
-    log.info(`[DEBUG] 브랜치 삭제 여부: ${deleteBranch}`);
 
     // 최종 확인
     const { confirm } = await inquirer.prompt([
@@ -566,8 +542,6 @@ export async function mergeCommand(prNumber: string): Promise<void> {
       return;
     }
 
-    log.info("[DEBUG] 병합 실행 시작");
-
     // PR 병합 실행
     await mergePullRequest({
       owner: repoInfo.owner,
@@ -580,11 +554,9 @@ export async function mergeCommand(prNumber: string): Promise<void> {
     });
 
     log.info(t("commands.merge.success.merged"));
-    log.info("[DEBUG] 병합 완료");
 
     // 로컬 브랜치 정리
     log.info(t("commands.merge.cleanup.start"));
-    log.info("[DEBUG] 로컬 브랜치 정리 시작");
 
     try {
       // 대상 브랜치로 전환
@@ -592,12 +564,10 @@ export async function mergeCommand(prNumber: string): Promise<void> {
         t("commands.merge.cleanup.switching_branch", { branch: pr.base.ref }),
       );
       execSync(`git checkout ${pr.base.ref}`, { stdio: "inherit" });
-      log.info(`[DEBUG] 브랜치 전환 완료: ${pr.base.ref}`);
 
       // 원격의 변경사항 가져오기
       log.info(t("commands.merge.cleanup.pulling_changes"));
       execSync(`git pull origin ${pr.base.ref}`, { stdio: "inherit" });
-      log.info("[DEBUG] 원격 변경사항 가져오기 완료");
 
       // PR 브랜치가 로컬에 있는 경우 삭제
       if (deleteBranch) {
@@ -609,11 +579,9 @@ export async function mergeCommand(prNumber: string): Promise<void> {
           );
           execSync(`git branch -D ${pr.head.ref}`, { stdio: "inherit" });
           log.info(t("commands.merge.cleanup.branch_deleted"));
-          log.info(`[DEBUG] 로컬 브랜치 삭제 완료: ${pr.head.ref}`);
         } catch (error) {
           // 브랜치가 이미 없는 경우 무시
           log.info(t("commands.merge.cleanup.branch_already_deleted"));
-          log.info("[DEBUG] 브랜치가 이미 삭제되어 있음");
         }
       }
     } catch (error) {
@@ -621,18 +589,12 @@ export async function mergeCommand(prNumber: string): Promise<void> {
         t("commands.merge.error.cleanup_failed", { error: String(error) }),
       );
       log.warn(t("commands.merge.error.manual_cleanup"));
-      log.error("[DEBUG] 로컬 브랜치 정리 실패:", String(error));
     }
   } catch (error) {
     if (error instanceof Error) {
       log.error(error.message);
-      log.error("[DEBUG] 에러 발생:", error.message);
-      if (error.stack) {
-        log.error("[DEBUG] 스택 트레이스:", error.stack);
-      }
     } else {
       log.error(t("common.error.unknown"), String(error));
-      log.error("[DEBUG] 알 수 없는 에러:", String(error));
     }
     process.exit(1);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -70,17 +70,17 @@ async function main() {
       .description(t("commands.commit.description"))
       .argument("[subcommand]", t("commands.commit.args.subcommand"))
       .argument("[message]", t("commands.commit.args.message"))
-      .option("-a, --all", t("commands.commit.options.all"))
+      .option("-a, --all", t("commands.commit.options.all_with_push"))
       .option("-p, --patch", t("commands.commit.options.patch"))
       .addHelpText(
         "after",
         `
         ${t("commands.commit.help.examples")}:
           $ autopr commit                    - ${t("commands.commit.help.default")}
-          $ autopr commit -a                 - ${t("commands.commit.help.all")}
+          $ autopr commit -a                 - ${t("commands.commit.help.all_with_push")}
           $ autopr commit improve            - ${t("commands.commit.help.improve_last")}
           $ autopr commit improve "message"  - ${t("commands.commit.help.improve_message")}
-          $ autopr commit improve -a         - ${t("commands.commit.help.improve_all")}
+          $ autopr commit improve -a         - ${t("commands.commit.help.improve_all_with_push")}
       `,
       )
       .action(commitCommand);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -250,9 +250,10 @@
       "description": "Merge a pull request",
       "info": {
         "title": "PR Information",
-        "author": "Author: {{author}}",
-        "branch": "Branch: {{branch}}",
-        "base_branch": "Target Branch: {{branch}}",
+        "branch_info": "Branch Information",
+        "pr_branch": "PR Branch: {{branch}}",
+        "target_branch": "Target Branch: {{branch}}",
+        "author": "PR Author: {{author}}",
         "checking_conflicts": "Checking for conflicts...",
         "cancelled": "Merge cancelled"
       },
@@ -418,7 +419,7 @@
     "commit": {
       "description": "Improve or suggest commit messages using AI",
       "options": {
-        "all": "Stage all changes before committing",
+        "all_with_push": "Stage all changes, commit and automatically push",
         "patch": "Interactively stage changes before committing"
       },
       "args": {
@@ -431,7 +432,9 @@
         "all": "Stage all changes and suggest a new commit message",
         "improve_last": "Improve the most recent commit message",
         "improve_message": "Improve the provided commit message",
-        "improve_all": "Stage all changes and improve the most recent commit message"
+        "improve_all": "Stage all changes and improve the most recent commit message",
+        "all_with_push": "Stage all changes, commit and automatically push",
+        "improve_all_with_push": "Stage all changes, improve the most recent commit message and automatically push"
       },
       "info": {
         "patch_mode": "Please run 'git add -p' to interactively stage changes",
@@ -445,10 +448,13 @@
         "no_staged_changes": "No staged changes found. Please stage your changes first using 'git add'",
         "invalid_subcommand": "Invalid subcommand. Use 'improve' or 'suggest'",
         "commit_failed": "Failed to create commit",
-        "staging_failed": "Failed to stage changes"
+        "staging_failed": "Failed to stage changes",
+        "get_branch_failed": "Failed to get current branch information",
+        "push_failed": "Failed to push to remote repository: {{error}}"
       },
       "success": {
-        "committed": "Successfully created commit with the improved message"
+        "committed": "Successfully created commit with the improved message",
+        "pushed": "Branch {{branch}} has been pushed to remote repository"
       },
       "commit_message": {
         "analyze": "Please analyze the following changes and write a commit message:\nCurrent message: {{message}}\nChanges: {{diff}}\n\nPlease write ONLY the commit message in the following format. Do not include any additional explanations or formatting:\n\ntype(scope): subject\n\nbody\n- change 1\n- change 2\n\nActual example:\nfeat(auth): add login functionality\n\nImplement user authentication system\n- Add JWT-based authentication\n- Create login API endpoint\n- Implement authentication middleware"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -252,9 +252,10 @@
       "description": "PR을 병합합니다",
       "info": {
         "title": "PR 정보",
-        "author": "작성자: {{author}}",
-        "branch": "브랜치: {{branch}}",
-        "base_branch": "대상 브랜치: {{branch}}",
+        "branch_info": "브랜치 정보",
+        "pr_branch": "PR 브랜치: {{branch}}",
+        "target_branch": "대상 브랜치: {{branch}}",
+        "author": "PR 작성자: {{author}}",
         "checking_conflicts": "충돌 확인 중...",
         "cancelled": "병합이 취소되었습니다"
       },
@@ -420,7 +421,7 @@
     "commit": {
       "description": "AI를 사용하여 커밋 메시지 개선 또는 제안",
       "options": {
-        "all": "모든 변경사항을 스테이징하고 커밋",
+        "all_with_push": "모든 변경사항을 스테이징하고 커밋 후 자동으로 push",
         "patch": "대화형으로 변경사항을 선택하여 스테이징"
       },
       "args": {
@@ -433,7 +434,9 @@
         "all": "모든 변경사항을 스테이징하고 새로운 커밋 메시지 생성",
         "improve_last": "가장 최근 커밋의 메시지를 개선",
         "improve_message": "주어진 메시지를 개선",
-        "improve_all": "모든 변경사항을 스테이징하고 최근 커밋 메시지를 개선"
+        "improve_all": "모든 변경사항을 스테이징하고 최근 커밋 메시지를 개선",
+        "all_with_push": "모든 변경사항을 스테이징하고 커밋 후 자동으로 push",
+        "improve_all_with_push": "모든 변경사항을 스테이징하고 최근 커밋 메시지를 개선 후 자동으로 push"
       },
       "info": {
         "patch_mode": "'git add -p' 명령어로 변경사항을 선택적으로 스테이징해주세요",
@@ -447,14 +450,17 @@
         "diff_failed": "스테이지된 변경사항을 가져오는데 실패했습니다",
         "no_staged_changes": "스테이지된 변경사항이 없습니다. 'git add'를 사용하여 변경사항을 스테이지해주세요",
         "invalid_subcommand": "잘못된 서브커맨드입니다. 'improve' 또는 'suggest'를 사용하세요",
-        "commit_failed": "커밋 생성에 실패했습니다"
+        "commit_failed": "커밋 생성에 실패했습니다",
+        "get_branch_failed": "현재 브랜치 정보를 가져오는데 실패했습니다",
+        "push_failed": "원격 저장소로 push하는데 실패했습니다: {{error}}"
       },
       "prompts": {
         "use_message": "이 커밋 메시지를 사용하시겠습니까?",
         "edit_message": "커밋 메시지 수정:"
       },
       "success": {
-        "committed": "개선된 메시지로 커밋이 성공적으로 생성되었습니다"
+        "committed": "개선된 메시지로 커밋이 성공적으로 생성되었습니다",
+        "pushed": "{{branch}} 브랜치가 원격 저장소로 push되었습니다"
       },
       "commit_message": {
         "analyze": "Please analyze the following changes and generate a commit message IN KOREAN:\nCurrent message: {{message}}\nChanges: {{diff}}\n\nPlease write the commit message in the following format. Do not include any additional explanations or formatting, just the commit message:\n\ntype(scope): Subject in Korean\n\nBody in Korean\n- Change 1\n- Change 2\n\nExample:\nfeat(인증): 로그인 기능 추가\n\n사용자 인증 시스템 구현\n- JWT 기반 인증 추가\n- 로그인 API 구현\n- 인증 미들웨어 추가\n\nImportant notes:\n1. Write everything in Korean except for this instruction\n2. Use conventional commit types (feat, fix, docs, etc)\n3. Keep the subject line concise and clear\n4. List actual changes from the diff in the body\n5. Do not make assumptions or guesses"


### PR DESCRIPTION
## 기능 설명
커밋 명령어에 `push` 옵션이 추가되어 변경 사항을 원격 저장소에 자동으로 푸시할 수 있는 기능이 개선되었습니다. 또한, 병합 명령어의 불필요한 디버그 로그가 제거되었고, 커밋 관련 옵션과 성공 메시지가 강화되었습니다.

## 구현 내용
- [V] 커밋 명령어에 `push` 옵션 추가
- [V] `-a` 옵션 활성화 시 자동으로 `push` 옵션 활성화
- [V] 커밋 후 원격 저장소로 푸시하는 기능 추가
- [V] 병합 명령어의 디버그 로그 제거 및 메시지 개선
- [V] PR 작성자, 브랜치 관련 메시지 추가 및 개선
- [V] 커밋 성공 메시지를 "브랜치가 원격 저장소로 push되었습니다"로 변경
- [V] 오류 메시지 추가로 실패 원인 명확화
- [V] UI 관련 언어 파일에서 변수 이름 변경

## 테스트
- [V] 단위 테스트 추가 (커밋 및 푸시 기능)
- [ ] 통합 테스트 수행
- [ ] E2E 테스트 (필요한 경우)

## 스크린샷 (UI 변경시)
UI 변경 사항이 없으므로 스크린샷이 없습니다.

## 관련 이슈
- 관련된 이슈 번호: 없음

## 체크리스트
- [V] 코드가 컨벤션을 준수하나요?
- [ ] 새로운 의존성이 추가되었나요?
- [ ] 성능에 영향을 주는 변경사항인가요?
- [V] 문서화가 필요한 부분이 있나요? (커밋 옵션 사용법 업데이트 필요)