### PR TITLE
[FIX] Draft Pr

### DIFF
--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -223,18 +223,18 @@ export async function newCommand(): Promise<void> {
       // pattern에서 draft 설정을 가져오되, draft PR 사용 불가능한 경우 false로 설정
       let isDraft = pattern?.draft ?? false;
 
-      // draft PR 사용 가능한 경우에만 draft 여부를 선택할 수 있도록 함
-      if (draftAvailable && !pattern?.draft) {
+      // draft PR 사용 가능한 경우 선택권 제공
+      if (draftAvailable) {
         const { shouldBeDraft } = await inquirer.prompt([
           {
             type: "confirm",
             name: "shouldBeDraft",
             message: t("commands.new.prompts.create_as_draft"),
-            default: false,
+            default: pattern?.draft ?? false,
           },
         ]);
         isDraft = shouldBeDraft;
-      } else if (!draftAvailable) {
+      } else {
         // draft PR 사용 불가능한 경우 강제로 false
         isDraft = false;
         if (pattern?.draft) {

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -831,26 +831,6 @@ export async function checkDraftPRAvailability(params: {
     const client = await getOctokit();
     const { data: repository } = await client.rest.repos.get(params);
 
-    // 디버깅을 위해 repository 객체의 모든 속성 출력
-    console.log("Repository data (raw):", repository);
-
-    // 주요 속성들 개별적으로 로깅
-    log.debug("Repository properties:");
-    log.debug(`- Name: ${repository.name}`);
-    log.debug(`- Private: ${repository.private}`);
-    log.debug(`- Has Issues: ${repository.has_issues}`);
-    log.debug(`- Has Projects: ${repository.has_projects}`);
-    log.debug(`- Has Wiki: ${repository.has_wiki}`);
-    log.debug(`- Has Pages: ${repository.has_pages}`);
-    log.debug(`- Has Downloads: ${repository.has_downloads}`);
-    log.debug(`- Has Discussions: ${repository.has_discussions}`);
-    if (repository.permissions) {
-      log.debug("Permissions:");
-      log.debug(`- Admin: ${repository.permissions.admin}`);
-      log.debug(`- Push: ${repository.permissions.push}`);
-      log.debug(`- Pull: ${repository.permissions.pull}`);
-    }
-
     // private 레포의 경우 draft PR 기능은 유료 기능입니다
     // 일단 private 여부로만 판단
     return !repository.private;

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -832,7 +832,24 @@ export async function checkDraftPRAvailability(params: {
     const { data: repository } = await client.rest.repos.get(params);
 
     // 디버깅을 위해 repository 객체의 모든 속성 출력
-    log.debug("Repository data:", JSON.stringify(repository, null, 2));
+    console.log("Repository data (raw):", repository);
+
+    // 주요 속성들 개별적으로 로깅
+    log.debug("Repository properties:");
+    log.debug(`- Name: ${repository.name}`);
+    log.debug(`- Private: ${repository.private}`);
+    log.debug(`- Has Issues: ${repository.has_issues}`);
+    log.debug(`- Has Projects: ${repository.has_projects}`);
+    log.debug(`- Has Wiki: ${repository.has_wiki}`);
+    log.debug(`- Has Pages: ${repository.has_pages}`);
+    log.debug(`- Has Downloads: ${repository.has_downloads}`);
+    log.debug(`- Has Discussions: ${repository.has_discussions}`);
+    if (repository.permissions) {
+      log.debug("Permissions:");
+      log.debug(`- Admin: ${repository.permissions.admin}`);
+      log.debug(`- Push: ${repository.permissions.push}`);
+      log.debug(`- Pull: ${repository.permissions.pull}`);
+    }
 
     // private 레포의 경우 draft PR 기능은 유료 기능입니다
     // 일단 private 여부로만 판단


### PR DESCRIPTION

# 이전 내용
## 버그 설명
Draft PR 기능 미지원 저장소에서 일반 PR을 생성하도록 하는 로직을 추가했습니다.

## 원인
Draft PR을 생성할 수 없는 저장소에서 사용자에게 적절한 안내가 없었습니다.

## 해결 방법
1. `checkDraftPRAvailability` 함수를 추가하여 Draft PR 사용 가능성을 확인하고, 이를 기반으로 PR 생성 안내 메시지를 조정했습니다.
2. 기존 PR 생성 메시지를 수정하고, 새로운 메시지 "regular_pr" 및 "manual_pr_required"를 추가했습니다.

## 테스트
- [V] 버그 재현 케이스 추가
- [V] 수정 사항 테스트
- [ ] 회귀 테스트

## 관련 이슈
- 버그 리포트: 없음

## 체크리스트
- [V] 다른 기능에 영향을 주지 않나요?
- [ ] 로깅이나 모니터링이 필요한가요?
- [ ] 성능에 영향을 주는 변경사항인가요?

---

### 변경 사항
1. `package.json`의 버전번호를 `0.1.3`에서 `0.1.4`로 업데이트했습니다.
2. `src/cli/commands/hook.ts` 파일에서 Draft PR 사용 가능 여부를 체크하여, 해당 여부에 따라 일반 PR 생성 안내 메시지를 추가했습니다.
3. `src/cli/commands/new.ts` 파일에서 새로운 명령어를 실행할 때 Draft PR 가능성을 체크하고, 사용자 선택이 가능하도록 변경했습니다.
4. `src/core/github.ts`에 `checkDraftPRAvailability`를 구현하여, 레포지토리의 프라이빗 여부를 확인하고 Draft PR 기능 사용 가능성을 판단합니다.
5. 로케일 파일(`src/i18n/locales/en.json`, `src/i18n/locales/ko.json`)에 Draft PR 관련 메시지를 추가했습니다. 

이러한 변경을 통해 사용자 경험을 개선하고, 올바른 PR 생성 방법을 안내할 수 있게 되었습니다.

---
# 업데이트된 내용
## 버그 설명
초안(PR) 기능의 사용 가능 여부를 확인하고, 이를 기반으로 PR을 생성하는 방법을 개선했습니다.

## 원인
기존에는 PR을 생성할 때 초안 기능을 사용할 수 없는 경우에 대한 처리가 미비했습니다. 따라서 사용자가 이를 인지하지 못하고 일반 PR을 자동으로 생성할 위험이 있었습니다.

## 해결 방법
초안(PR) 기능의 사용 가능 여부를 확인하는 새로운 함수를 추가하고, 이를 통해 사용자가 초안 기능을 사용할 수 없는 경우 일반 PR을 생성하도록 안내하는 로직을 추가했습니다. 또한, 관련 사용자에게 적절한 메시지를 출력하여 이해를 돕도록 했습니다.

## 테스트
- [V] 버그 재현 케이스 추가
- [V] 수정 사항 테스트
- [V] 회귀 테스트

## 관련 이슈
- 버그 리포트: #

## 체크리스트
- [V] 다른 기능에 영향을 주지 않나요?
- [ ] 로깅이나 모니터링이 필요한가요?
- [ ] 성능에 영향을 주는 변경사항인가요?

### 상세 변경 사항
1. **package.json**: 버전 번호를 0.1.3에서 0.1.4로 업데이트했습니다.
2. **src/cli/commands/hook.ts**:
   - 초안(PR) 사용 가능 여부를 확인하는 `checkDraftPRAvailability` 함수를 추가했습니다.
   - 원격 브랜치가 존재하지 않는 경우에, 초안 PR이 사용 불가능할 경우 일반 PR 생성을 안내하는 로직을 추가했습니다.
3. **src/cli/commands/new.ts**:
   - PR 생성 시 초안 기능 사용 가능 여부를 확인하도록 변경했습니다.
   - 초안 PR을 생성할 수 없는 경우 강제로 초안 설정을 false로 변경하고 경고 메시지를 출력하도록 했습니다.
4. **src/core/github.ts**:
   - 초안 PR 사용 가능 여부를 확인하는 로직을 추가했습니다. 비공식 저장소의 초안 PR 기능이 유료인 점을 반영하였습니다.
5. **src/i18n/locales/en.json** 및 **src/i18n/locales/ko.json**: 사용자 안내 메시지를 추가 및 수정하여 초안 PR 기능의 가용성에 대한 정보를 포함시켰습니다. 

이러한 변화들은 사용자가 PR을 생성할 때 더 명확한 정보를 제공하고, 혼란을 줄이기 위해 설계되었습니다.
