### PR TITLE
[CHORE] 버전 번호를 0.1.6으로 업데이트

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,7 +26,7 @@ async function main() {
     program
       .name("autopr")
       .description(t("common.cli.description"))
-      .version("0.1.0");
+      .version("0.1.6");
 
     // 기본 명령어들
     program


### PR DESCRIPTION
## 변경 사항
CLI 버전 번호를 0.1.0에서 0.1.6으로 업데이트했습니다.

## 변경 이유
CLI 버전 업데이트는 새로운 기능 추가 및 버그 수정 사항을 사용자에게 알리기 위한 것입니다. 버전 관리의 일관성을 유지하기 위해 필요했습니다.

## 영향 범위
- [ ] 빌드 시스템
- [ ] 의존성
- [ ] 설정 파일
- [ ] 기타

## 체크리스트
- [V] src/cli/index.ts 파일의 버전 번호가 0.1.0에서 0.1.6으로 변경되었습니다 (라인 7). 

## 구현 세부 사항
- [src/cli/index.ts:7] `.version("0.1.0");`에서 `.version("0.1.6");`으로 변경되었습니다. 이 변경은 CLI 도구의 현재 버전을 업데이트하여 사용자가 최신 버전에 대한 정보를 확인할 수 있도록 합니다.

## 테스트
변경된 테스트는 없습니다.

## 영향 분석
- CLI의 버전 번호 변경은 사용자의 인식에 영향을 미치지만, 직접적인 기능적 변화는 없습니다. 각 기능은 이전과 동일하게 작동합니다.