### PR TITLE
[FEAT] release 브랜치 자동 푸시 기능 추가


### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -136,7 +136,8 @@
         "create_failed": "Failed to create PR: {{error}}",
         "diff_failed": "Failed to get diff content",
         "files_failed": "Failed to get changed files",
-        "protected_branch": "Cannot create PR from protected branch '{{branch}}'. Please create a new branch from '{{development}}' or '{{production}}'."
+        "protected_branch": "Cannot create PR from protected branch '{{branch}}'. Please create a new branch from '{{development}}' or '{{production}}'.",
+        "push_failed": "Failed to push to remote repository: {{error}}"
       },
       "info": {
         "pr_exists": "PR #{{number}} already exists.",
@@ -165,7 +166,8 @@
       "success": {
         "pr_updated": "PR #{{number}} has been successfully updated.",
         "cancelled": "Operation cancelled.",
-        "pr_created": "Pull Request has been successfully created."
+        "pr_created": "Pull Request has been successfully created.",
+        "branch_pushed": "Branch {{branch}} has been pushed to remote repository."
       }
     },
     "list": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -134,10 +134,11 @@
       "description": "새로운 Pull Request 생성",
       "error": {
         "main_branch": "{{branch}} 브랜치에서 직접 PR을 생성할 수 없습니다. 새로운 브랜치를 먼저 생성해주세요.",
-        "create_failed": "PR 생성 실패: {{error}}",
-        "diff_failed": "변경사항 내용을 가져오는데 실패했습니다",
+        "create_failed": "PR 생성에 실패했습니다: {{error}}",
+        "diff_failed": "변경사항을 가져오는데 실패했습니다",
         "files_failed": "변경된 파일 목록을 가져오는데 실패했습니다",
-        "protected_branch": "보호된 브랜치 '{{branch}}'에서 직접 PR을 생성할 수 없습니다. '{{development}}' 또는 '{{production}}'에서 새 브랜치를 생성해주세요."
+        "protected_branch": "보호된 브랜치 '{{branch}}'에서 직접 PR을 생성할 수 없습니다. '{{development}}' 또는 '{{production}}'에서 새 브랜치를 생성해주세요.",
+        "push_failed": "원격 저장소에 푸시하는데 실패했습니다: {{error}}"
       },
       "prompts": {
         "update_existing": "기존 PR을 업데이트하시겠습니까?",
@@ -166,7 +167,8 @@
       "success": {
         "pr_updated": "PR #{{number}}이(가) 성공적으로 업데이트되었습니다.",
         "cancelled": "작업이 취소되었습니다.",
-        "pr_created": "Pull Request가 성공적으로 생성되었습니다."
+        "pr_created": "Pull Request가 성공적으로 생성되었습니다.",
+        "branch_pushed": "브랜치 {{branch}}이(가) 원격 저장소에 푸시되었습니다."
       }
     },
     "list": {
@@ -488,7 +490,7 @@
         "invalid_subcommand": "잘못된 서브커맨드입니다. 'improve' 또는 'suggest'를 사용하세요",
         "commit_failed": "커밋 생성에 실패했습니다",
         "get_branch_failed": "현재 브랜치 정보를 가져오는데 실패했습니다",
-        "push_failed": "원격 저장소로 push하는데 실패했습니다: {{error}}"
+        "push_failed": "원격 저장소에 푸시하는데 실패했습니다: {{error}}"
       },
       "prompts": {
         "use_message": "이 커밋 메시지를 사용하시겠습니까?",


### PR DESCRIPTION
## 기능 설명
본 PR은 `new` 커맨드를 개선하여 `release/*` 브랜치에서 PR 생성 시 자동으로 원격 저장소에 브랜치를 푸시하는 기능을 추가합니다. 또한, 푸시 실패에 대한 에러 처리 및 사용자에게 피드백을 제공하는 로직을 개선했습니다. i18n 관련 로케일 파일(en.json, ko.json)에 관련된 번역 문구를 추가했습니다.

## 구현 내용
- [src/cli/commands/new.ts] `pushToRemote` 함수를 추가하여 지정된 브랜치를 원격 저장소에 푸시합니다. 이 함수는 `git push -u origin ${branch}` 명령을 실행하고, 성공 또는 실패 시 로그 메시지를 출력합니다.
- [src/cli/commands/new.ts] `newCommand` 함수 내에서 현재 브랜치가 `release/*` 패턴과 일치하는 경우, `pushToRemote` 함수를 호출하여 브랜치를 푸시합니다. 푸시 실패 시 오류 메시지를 출력하고 프로세스를 종료합니다.
- [src/i18n/locales/en.json] "commands.new.error.push_failed" 및 "commands.new.success.branch_pushed" 키에 대한 영어 번역 문구를 추가했습니다.
- [src/i18n/locales/ko.json] "commands.new.error.push_failed" 및 "commands.new.success.branch_pushed" 키에 대한 한국어 번역 문구를 추가했습니다.

## 테스트
- [ ] `release/*` 브랜치에서 `new` 커맨드를 실행했을 때 브랜치가 원격 저장소에 성공적으로 푸시되는지 확인하는 테스트 케이스를 추가해야 합니다.
- [ ] 원격 저장소에 푸시가 실패했을 때 에러 메시지가 정확하게 표시되고 프로세스가 종료되는지 확인하는 테스트 케이스를 추가해야 합니다.

## 영향 분석
- `release/*` 브랜치에서 PR 생성 시 원격 저장소에 자동으로 푸시되므로, 개발 워크플로우가 개선될 수 있습니다.
- 푸시 실패 시 사용자에게 오류 메시지가 표시되므로, 문제 해결에 도움이 될 수 있습니다.
- 새로운 i18n 키가 추가되었으므로, 다국어 지원이 강화되었습니다.

## 관련 이슈
- 관련된 이슈 번호: #N/A

## 체크리스트
- [ ] 코드가 컨벤션을 준수하나요?
- [ ] 새로운 의존성이 추가되었나요? (No)
- [ ] 성능에 영향을 주는 변경사항인가요? (푸시 과정에서 약간의 시간 소요가 있을 수 있습니다.)
- [ ] 문서화가 필요한 부분이 있나요? (새로운 기능에 대한 사용자 문서 업데이트 필요)
