### PR TITLE
[FEAT] 이슈 댓글 이벤트 처리 기능 추가

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,6 +8,8 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  issue_comment:
+    types: [created]
 
 # 명시적으로 권한 설정 추가
 permissions:
@@ -22,16 +24,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
-          cache: 'npm'
-      
+          node-version: "18"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run PR Review Bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -188,6 +188,8 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  issue_comment:
+    types: [created]
 
 # 명시적으로 권한 설정 추가
 permissions:


### PR DESCRIPTION
## 기능 설명
본 PR은 다음과 같은 변경 사항을 포함합니다.

- `pr-review.yml` 워크플로우에 `issue_comment` 이벤트 트리거를 추가하여 이슈 댓글이 생성될 때 워크플로우가 실행되도록 합니다.
- `init.ts` 파일에 `issue_comment` 이벤트 트리거를 추가합니다.
- `review-bot.ts` 파일에서 이슈 댓글 이벤트 핸들링 로직을 추가하여 PR 관련 이슈에 대한 댓글을 처리할 수 있도록 합니다.

## 구현 내용

- `.github/workflows/pr-review.yml`:
    - `on` 트리거에 `issue_comment` 이벤트를 추가하여 이슈 댓글 생성 시 워크플로우가 실행되도록 변경했습니다.
    - `permissions` 섹션은 변경되지 않았습니다.

- `src/cli/commands/init.ts`:
    - `on` 트리거에 `issue_comment` 이벤트를 추가하여 이슈 댓글 생성 시 워크플로우가 실행되도록 변경했습니다.
    - `permissions` 섹션은 변경되지 않았습니다.

- `src/cli/commands/review-bot.ts`:
    - `CommentEvent` 인터페이스의 `pull_request` 속성을 optional로 변경했습니다 (`pull_request?:`). 이는 일반 이슈 댓글의 경우 `pull_request` 정보가 없을 수 있기 때문입니다.
    - `CommentEvent` 인터페이스에 `issue` 속성을 추가하여 이슈 관련 정보를 담을 수 있도록 했습니다. `issue` 속성은 `number`, `title`, `body?`, `pull_request?` 필드를 포함합니다.
    - `handleCommentEvent` 함수 내에서 `pull_request` 속성이 없는 경우 (일반 이슈 댓글인 경우) 로깅 후 함수를 종료하도록 로직을 추가했습니다.
    - `reviewBotCommand` 함수 내에서 `issue_comment` 이벤트 처리 로직을 추가했습니다. `payload.issue`와 `payload.issue.pull_request`를 확인하여 PR 관련 이슈 댓글인 경우에만 `handleCommentEvent`를 호출하도록 했습니다. `CommentEvent` 인터페이스와 맞지 않을 수 있으므로 필요한 필드를 매핑하여 `handleCommentEvent`에 전달합니다. PR 관련 댓글이 아닌 경우 로깅 후 무시합니다.

## 테스트
- [ ] `reviewBotCommand` 함수에 추가된 `issue_comment` 이벤트 처리 로직에 대한 단위 테스트를 추가해야 합니다.
- [ ] PR 관련 이슈에 댓글을 추가했을 때 리뷰 봇이 정상적으로 동작하는지 확인하는 통합 테스트를 수행해야 합니다.

## 영향 분석
- **기능 변경**: PR 관련 이슈에 대한 댓글을 리뷰 봇이 처리할 수 있게 되었습니다.
- **종속성 변경**:  새로운 종속성은 추가되지 않았습니다.
- **구현 복잡도**: `issue_comment` 이벤트 핸들링 로직이 추가됨에 따라 코드 복잡도가 증가했습니다.

## 체크리스트
- [ ] 코드가 컨벤션을 준수하나요?
- [ ] 성능에 영향을 주는 변경사항인가요? (영향 없음)
- [ ] 문서화가 필요한 부분이 있나요? (필요 없음)
