### PR TITLE
[FEAT] PR 리뷰 시 라인 위치 정보 추가 및 오류 수정

### DIFF
--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -160,11 +160,19 @@ async function performAICodeReview(params: {
         const commitSha = latestCommit.sha;
 
         // PR 리뷰 코멘트 구성
-        const comments = reviewResult.lineComments.map((comment) => ({
-          path: comment.path,
-          line: comment.line,
-          body: comment.comment,
-        }));
+        const comments = reviewResult.lineComments
+          .map((comment) => ({
+            path: comment.path,
+            position: comment.position,
+            body: comment.comment,
+          }))
+          .filter((comment) => comment.position !== undefined);
+
+        // 코멘트가 없는 경우 리뷰를 건너뜀
+        if (comments.length === 0) {
+          log.warn("유효한 라인 코멘트가 없어 리뷰를 생성하지 않습니다.");
+          return;
+        }
 
         // PR 리뷰 생성
         await client.rest.pulls.createReview({

--- a/src/cli/commands/review-bot.ts
+++ b/src/cli/commands/review-bot.ts
@@ -192,11 +192,19 @@ async function handlePREvent(event: PREvent, octokit: Octokit): Promise<void> {
         const commitSha = latestCommit.sha;
 
         // PR 리뷰 코멘트 구성
-        const comments = reviewResult.lineComments.map((comment) => ({
-          path: comment.path,
-          line: comment.line,
-          body: comment.comment,
-        }));
+        const comments = reviewResult.lineComments
+          .map((comment) => ({
+            path: comment.path,
+            position: comment.position,
+            body: comment.comment,
+          }))
+          .filter((comment) => comment.position !== undefined);
+
+        // 코멘트가 없는 경우 리뷰를 건너뜀
+        if (comments.length === 0) {
+          log.warn("유효한 라인 코멘트가 없어 리뷰를 생성하지 않습니다.");
+          return;
+        }
 
         // PR 리뷰 생성
         await octokit.pulls.createReview({


### PR DESCRIPTION
## 기능 설명
본 PR은 AI 코드 리뷰 기능의 정확성을 개선하고, 불필요한 리뷰 생성 시도를 방지하기 위해 다음과 같은 변경사항을 포함합니다. 구체적으로, 라인 코멘트 생성 시 GitHub PR의 `position` 정보를 활용하여 코멘트 위치를 정확하게 지정하고, 유효한 라인 코멘트가 없는 경우 리뷰 생성을 건너뛰도록 로직을 개선했습니다. 또한, diff 파싱 로직을 수정하여 각 라인의 위치 정보를 정확하게 추적하도록 했습니다.

## 구현 내용
- [src/cli/commands/new.ts]
    - [V] `performAICodeReview` 함수 내에서 `reviewResult.lineComments`를 처리할 때, `position` 값이 존재하는 코멘트만 필터링하도록 수정했습니다.
    - [V] 유효한 라인 코멘트가 없는 경우, 리뷰 생성을 건너뛰고 경고 메시지를 출력하도록 로직을 추가했습니다.
- [src/cli/commands/review-bot.ts]
    - [V] `handlePREvent` 함수 내에서 `reviewResult.lineComments`를 처리할 때, `position` 값이 존재하는 코멘트만 필터링하도록 수정했습니다.
    - [V] 유효한 라인 코멘트가 없는 경우, 리뷰 생성을 건너뛰고 경고 메시지를 출력하도록 로직을 추가했습니다.
- [src/core/ai-features.ts]
    - [V] `PRReviewResult` 인터페이스에 `position?: number` 속성을 추가하여 라인 코멘트의 위치 정보를 선택적으로 포함할 수 있도록 변경했습니다.
    - [V] `generateLineComments` 함수가 반환하는 라인 코멘트 배열의 타입을 `Array<{ path: string; line: number; position: number; comment: string }>`로 변경하여 `position` 정보를 포함하도록 했습니다.
    - [V] `generateLineComments` 함수 내에서 라인 번호에 해당하는 `position` 정보를 찾아 코멘트에 추가하도록 로직을 추가했습니다. `changedLines`에서 라인 번호와 일치하는 `position`을 찾고, 없을 경우 디버그 로그를 출력합니다.
    - [V] `parseDiffContent` 함수가 반환하는 데이터 구조에 `position` 정보를 포함하도록 변경했습니다. 각 라인의 `position` 값을 추적하여 결과에 포함시킵니다. diff 파일의 각 라인을 순회하면서 `position` 값을 증가시키고, '+'로 시작하는 라인에 대해 해당 `position`을 저장합니다.

## 테스트
- [ ] `generateLineComments` 함수에 대한 단위 테스트를 추가하여, 라인 코멘트 생성 시 `position` 정보가 정확하게 포함되는지 확인해야 합니다.
- [ ] `parseDiffContent` 함수에 대한 단위 테스트를 추가하여, diff 콘텐츠 파싱 시 각 라인의 `position` 정보가 정확하게 추출되는지 확인해야 합니다.
- [ ] E2E 테스트를 통해 실제 PR 환경에서 AI 리뷰가 정상적으로 생성되고, 코멘트 위치가 정확하게 표시되는지 확인해야 합니다.

## 영향 분석
- AI 코드 리뷰 기능의 정확도가 향상되어, 개발자가 더 정확한 피드백을 받을 수 있습니다.
- 유효한 라인 코멘트가 없는 경우 불필요한 리뷰 생성을 방지하여 GitHub API 사용량을 줄이고, 리뷰 생성 실패로 인한 오류를 예방할 수 있습니다.
- `parseDiffContent` 함수의 변경으로 인해 diff 파싱 로직에 의존하는 다른 기능에 잠재적인 영향이 있을 수 있으므로, 해당 기능들을 면밀히 검토해야 합니다.

## 관련 이슈
- 관련된 이슈 번호: # <!-- 관련된 이슈 번호 -->

## 체크리스트
- [ ] 코드가 컨벤션을 준수하나요?
- [ ] 새로운 의존성이 추가되었나요?
- [ ] 성능에 영향을 주는 변경사항인가요?
- [ ] 문서화가 필요한 부분이 있나요?
