### PR TITLE
[FEAT] PR 리뷰 봇 응답 기능 개선 및 이벤트 확장

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,15 +11,21 @@ on:
   issue_comment:
     types: [created]
 
-# 명시적으로 권한 설정 추가
+# 명시적으로 권한 설정 강화
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write # OIDC 인증에 필요한 권한 추가
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    # issue_comment 이벤트가 PR 관련 댓글인 경우에만 실행
+    if: |
+      (github.event_name != 'issue_comment') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,7 +40,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Debug Event Info
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Actor: ${{ github.actor }}"
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            echo "Comment author: ${{ github.event.comment.user.login }}"
+            echo "Is bot comment: ${{ contains(github.event.comment.user.login, 'bot') || github.event.comment.user.login == 'github-actions[bot]' }}"
+          fi
+
+      # 봇이 작성한 코멘트에는 응답하지 않음
       - name: Run PR Review Bot
+        if: |
+          !(github.event_name == 'issue_comment' && 
+            (contains(github.event.comment.user.login, 'bot') || 
+             github.event.comment.user.login == 'github-actions[bot]'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: "openrouter"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -745,11 +745,15 @@
       },
       "info": {
         "processing_pr": "Processing PR #{{number}}",
-        "processing_comment": "Processing comment #{{id}}"
+        "processing_comment": "Processing comment #{{id}}",
+        "processing_review_comment": "Processing review comment #{{id}}",
+        "processing_review": "Processing PR review"
       },
       "success": {
         "review_created": "Review created for PR #{{number}}",
-        "comment_response_created": "Response created for comment #{{id}}"
+        "comment_response_created": "Response created for comment #{{id}}",
+        "review_comment_response_created": "Response created for review comment #{{id}}",
+        "review_response_created": "Response created for PR review"
       },
       "error": {
         "no_github_token": "GITHUB_TOKEN not found in environment variables",
@@ -758,10 +762,25 @@
         "missing_event_or_payload": "Missing event type or payload",
         "execution_failed": "PR review bot execution failed",
         "review_failed": "Failed to create PR review",
-        "comment_response_failed": "Failed to create comment response"
+        "comment_response_failed": "Failed to create comment response",
+        "review_comment_response_failed": "Failed to create review comment response",
+        "unauthorized": "Unauthorized access to GitHub API",
+        "auth_error": "Error retrieving authentication information"
       },
       "warning": {
-        "unsupported_event": "Unsupported event type: {{event}}"
+        "unsupported_event": "Unsupported event type: {{event}}",
+        "bot_comment": "Ignoring bot's comment",
+        "already_responded": "Already responded to this comment",
+        "access_denied": "Access denied to resource"
+      },
+      "debug": {
+        "auth_user": "Authenticated user: {{username}}",
+        "auth_failed": "Failed to get authenticated user: {{error}}",
+        "default_bot": "Using default bot username: {{username}}",
+        "ignore_own_comment": "Ignoring own comment",
+        "ignore_bot_comment": "Ignoring bot's comment",
+        "already_responded_to": "Already responded to {{id}}",
+        "not_pr_comment": "Not a PR related comment, ignoring"
       }
     }
   },

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -743,24 +743,43 @@
         "payload": "이벤트 페이로드 (JSON 문자열)"
       },
       "info": {
-        "processing_pr": "PR #{{number}} 처리 중",
-        "processing_comment": "코멘트 #{{id}} 처리 중"
+        "processing_pr": "PR #{{number}}를 처리 중입니다",
+        "processing_comment": "코멘트 ID {{id}}를 처리 중입니다",
+        "processing_review_comment": "리뷰 코멘트 ID {{id}}를 처리 중입니다",
+        "processing_review": "PR 리뷰를 처리 중입니다"
       },
       "success": {
         "review_created": "PR #{{number}}에 대한 리뷰가 생성되었습니다",
-        "comment_response_created": "코멘트 #{{id}}에 대한 응답이 생성되었습니다"
+        "comment_response_created": "코멘트 ID {{id}}에 대한 응답이 생성되었습니다",
+        "review_comment_response_created": "리뷰 코멘트 ID {{id}}에 대한 응답이 생성되었습니다",
+        "review_response_created": "PR 리뷰에 대한 응답이 생성되었습니다"
       },
       "error": {
-        "no_github_token": "환경 변수에서 GITHUB_TOKEN을 찾을 수 없습니다",
-        "invalid_payload": "잘못된 페이로드 JSON",
+        "no_github_token": "GitHub 토큰을 찾을 수 없습니다",
+        "invalid_payload": "유효하지 않은 페이로드입니다",
         "event_file_read": "이벤트 파일을 읽는데 실패했습니다",
-        "missing_event_or_payload": "이벤트 유형 또는 페이로드가 없습니다",
-        "execution_failed": "PR 리뷰 봇 실행에 실패했습니다",
+        "missing_event_or_payload": "이벤트 또는 페이로드가 없습니다",
+        "execution_failed": "PR 리뷰 봇 실행 중 오류가 발생했습니다",
         "review_failed": "PR 리뷰 생성에 실패했습니다",
-        "comment_response_failed": "코멘트 응답 생성에 실패했습니다"
+        "comment_response_failed": "코멘트 응답 생성에 실패했습니다",
+        "review_comment_response_failed": "리뷰 코멘트 응답 생성 중 오류가 발생했습니다",
+        "unauthorized": "GitHub API 접근 권한이 없습니다",
+        "auth_error": "인증 정보를 가져오는 중 오류가 발생했습니다"
       },
       "warning": {
-        "unsupported_event": "지원하지 않는 이벤트 유형: {{event}}"
+        "unsupported_event": "지원하지 않는 이벤트 타입입니다: {{event}}",
+        "bot_comment": "봇의 코멘트는 무시합니다",
+        "already_responded": "이미 응답한 코멘트입니다",
+        "access_denied": "리소스에 접근할 수 없습니다"
+      },
+      "debug": {
+        "auth_user": "인증된 사용자: {{username}}",
+        "auth_failed": "인증된 사용자 정보를 가져올 수 없습니다: {{error}}",
+        "default_bot": "기본 봇 사용자 이름을 사용합니다: {{username}}",
+        "ignore_own_comment": "자신의 코멘트는 무시합니다",
+        "ignore_bot_comment": "봇의 코멘트는 무시합니다",
+        "already_responded_to": "이미 {{id}}에 응답했습니다",
+        "not_pr_comment": "PR 관련 댓글이 아니므로 무시합니다"
       }
     }
   },


### PR DESCRIPTION
## 기능 설명
본 PR은 GitHub Actions 워크플로우를 개선하고, PR 리뷰 봇이 PR 리뷰, 코멘트, 라인 코멘트에 대해 응답하는 기능을 확장합니다. 봇이 자신의 댓글이나 다른 봇의 댓글에 응답하지 않도록 로직을 개선하고, 권한 설정을 강화하여 OIDC 인증을 지원합니다. 또한, i18n 로케일 파일에 새로운 번역을 추가하여 사용자 경험을 개선합니다.

## 구현 내용
- [ ] `.github/workflows/pr-review.yml`:
    - `permissions` 섹션에 `id-token: write` 권한을 추가하여 OIDC 인증에 필요한 권한을 명시적으로 설정했습니다.
    - `issue_comment` 이벤트가 PR 관련 댓글인 경우에만 워크플로우가 실행되도록 조건을 추가했습니다.
    - 봇이 작성한 코멘트에는 응답하지 않도록 조건을 추가했습니다.
    - 디버깅을 위해 이벤트 정보를 출력하는 단계를 추가했습니다.
- [ ] `src/cli/commands/review-bot.ts`:
    - `PRReviewEvent` 인터페이스를 추가하여 PR 리뷰 이벤트를 처리할 수 있도록 했습니다.
    - `handleCommentEvent` 함수에서 PR 번호를 `pull_request` 또는 `issue.pull_request`에서 가져오도록 수정하여 일반 이슈 댓글이 아닌 PR 관련 댓글만 처리하도록 했습니다.
    - `handleCommentEvent` 및 `handlePRReviewCommentEvent` 함수에서 봇의 코멘트를 무시하는 로직을 추가하고, 이미 응답한 코멘트에 다시 응답하지 않도록 로직을 개선했습니다. 코멘트 ID를 추적하여 중복 응답을 방지합니다.
    - `handlePRReviewEvent` 함수를 추가하여 PR 리뷰 이벤트(PR 전체에 대한 리뷰)를 처리하고, AI를 사용하여 리뷰에 대한 응답을 생성하도록 했습니다.
    - 봇 사용자 정보를 가져올 때 권한 오류가 발생할 경우를 대비하여 `try-catch` 블록을 추가하고, 기본 봇 사용자 이름을 사용하도록 했습니다.
    - 코멘트 응답 시 원본 코멘트 ID 또는 리뷰 ID를 포함하도록 하여 응답의 출처를 명확히 했습니다.
- [ ] `src/i18n/locales/en.json`:
    - PR 리뷰 처리, 리뷰 코멘트 처리, 봇 코멘트 무시, 이미 응답한 코멘트 등의 새로운 번역 문자열을 추가했습니다.
    - 인증 오류 관련 메시지 추가
- [ ] `src/i18n/locales/ko.json`:
    - PR 리뷰 처리, 리뷰 코멘트 처리, 봇 코멘트 무시, 이미 응답한 코멘트 등의 새로운 번역 문자열을 추가했습니다.
    - 인증 오류 관련 메시지 추가

## 테스트
- [ ] 봇이 자신의 코멘트나 다른 봇의 코멘트에 응답하지 않는지 확인하는 테스트를 추가해야 합니다.
- [ ] PR 리뷰 이벤트 처리 로직을 검증하는 테스트를 추가해야 합니다.
- [ ] 권한 오류 발생 시 기본 봇 사용자 이름을 사용하는 로직을 검증하는 테스트를 추가해야 합니다.
- [ ] 다양한 이벤트 페이로드를 사용하여 봇의 응답을 테스트해야 합니다.

## 영향 분석
- PR 리뷰 봇이 PR 리뷰, 코멘트, 라인 코멘트에 대해 응답하는 기능이 확장되었습니다.
- 봇이 자신의 댓글이나 다른 봇의 댓글에 응답하지 않도록 로직이 개선되어 불필요한 응답을 줄였습니다.
- OIDC 인증 지원을 위한 권한 설정이 추가되어 보안이 강화되었습니다.
- i18n 로케일 파일에 새로운 번역이 추가되어 사용자 경험이 개선되었습니다.
- 봇의 응답에 코멘트 ID 또는 리뷰 ID가 포함되어 응답의 출처를 쉽게 확인할 수 있습니다.

## 체크리스트
- [ ] 코드가 컨벤션을 준수하나요?
- [ ] 새로운 의존성이 추가되었나요?
- [ ] 성능에 영향을 주는 변경사항인가요?
- [ ] 문서화가 필요한 부분이 있나요?
