### PR TITLE
[FEAT] PR 리뷰 봇, 리뷰 코멘트 처리 기능 추가

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,6 +22,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     # issue_comment 이벤트가 PR 관련 댓글인 경우에만 실행
+    # pull_request_review_comment 이벤트에서는 리뷰의 일부가 아닐 때만 실행
     if: |
       (github.event_name != 'issue_comment') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request)
@@ -48,13 +49,18 @@ jobs:
             echo "Comment author: ${{ github.event.comment.user.login }}"
             echo "Is bot comment: ${{ contains(github.event.comment.user.login, 'bot') || github.event.comment.user.login == 'github-actions[bot]' }}"
           fi
+          if [[ "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
+            echo "Is part of review: ${{ github.event.pull_request_review != null }}"
+          fi
 
       # 봇이 작성한 코멘트에는 응답하지 않음
       - name: Run PR Review Bot
         if: |
-          !(github.event_name == 'issue_comment' && 
+          !((github.event_name == 'issue_comment' && 
             (contains(github.event.comment.user.login, 'bot') || 
-             github.event.comment.user.login == 'github-actions[bot]'))
+             github.event.comment.user.login == 'github-actions[bot]')) ||
+           (github.event_name == 'pull_request_review_comment' && 
+            github.event.pull_request_review != null))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: "openrouter"


### PR DESCRIPTION
## 기능 설명
본 PR은 PR 리뷰 봇이 PR에 달린 코멘트에 응답하는 방식을 개선합니다. 구체적으로, `pull_request_review_comment` 이벤트가 발생했을 때, 해당 코멘트가 리뷰의 일부인지 여부를 판단하여, 리뷰의 일부인 경우에는 중복 처리를 방지하고, 리뷰가 제출될 때 일괄적으로 처리하도록 변경합니다. 또한, Conversation 탭과 Files changed 탭에서 작성된 코멘트를 구분하여 로깅하도록 개선했습니다.

## 구현 내용
- [.github/workflows/pr-review.yml]
    - `pull_request_review_comment` 이벤트가 발생했을 때, `github.event.pull_request_review` 필드가 null이 아닌 경우 (리뷰의 일부인 경우) 봇이 실행되지 않도록 워크플로우 조건을 수정했습니다. 이는 리뷰가 제출될 때 일괄적으로 처리하기 위함입니다.
    - issue_comment 이벤트 처리 조건에 봇이 작성한 코멘트인지 확인하는 로직을 추가하여 봇이 자신의 코멘트에 응답하지 않도록 수정했습니다.
- [src/cli/commands/review-bot.ts]
    - `PRReviewCommentEvent` 인터페이스에 `pull_request_review` 필드를 추가하여, `pull_request_review_comment` 이벤트에서 리뷰 정보를 가져올 수 있도록 했습니다.
    - `handlePRReviewCommentEvent` 함수에서 `pull_request_review` 필드가 존재하는 경우 (리뷰의 일부인 코멘트인 경우), 해당 코멘트를 즉시 처리하지 않고, 리뷰가 제출될 때 처리하도록 로직을 변경했습니다.
    - Conversation 탭에서 작성된 코멘트와 Files changed 탭에서 작성된 코멘트를 구분하여 로깅하도록 개선했습니다.
    - 코멘트 ID를 로깅하는 메시지를 개선하여 어떤 코멘트가 처리되고 있는지 명확하게 알 수 있도록 했습니다.

## 테스트
- [ ] `pull_request_review_comment` 이벤트가 발생했을 때, 리뷰의 일부인 코멘트가 무시되는지 확인하는 테스트를 추가해야 합니다.
- [ ] Conversation 탭과 Files changed 탭에서 코멘트가 올바르게 로깅되는지 확인하는 테스트를 추가해야 합니다.

## 영향 분석
- PR 리뷰 봇이 리뷰의 일부인 코멘트에 중복 응답하는 문제를 해결하여, 봇의 효율성을 높였습니다.
- Conversation 탭과 Files changed 탭에서 작성된 코멘트를 구분하여 로깅함으로써, 디버깅 및 문제 해결에 도움을 줄 수 있습니다.
- 워크플로우 조건 변경으로 인해, 특정 이벤트에서 봇이 실행되지 않도록 변경되었으므로, 주의가 필요합니다.

## 체크리스트
- [ ] 코드가 컨벤션을 준수하나요?
- [ ] 새로운 의존성이 추가되었나요?
- [ ] 성능에 영향을 주는 변경사항인가요?
- [ ] 문서화가 필요한 부분이 있나요?
