### PR TITLE
[FEAT] PR 리뷰 봇 이벤트 처리 방식 개선

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -53,10 +53,20 @@ jobs:
             echo "Is part of review: ${{ github.event.pull_request_review != null }}"
           fi
 
+      # 처리 방식을 이벤트 타입에 따라 분리
+      # pull_request 이벤트는 직접 실행
+      - name: Run PR Review Bot for pull_request events
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AI_PROVIDER: "openrouter"
+        run: npx autopr review-bot
+
       # 봇이 작성한 코멘트에는 응답하지 않음
-      # PR 리뷰 봇 실행 및 결과 저장
-      - name: Run PR Review Bot and Store Output
+      # 다른 이벤트 유형에 대해서는 봇 결과를 저장하고 응답 생성
+      - name: Run PR Review Bot and Store Output for comment events
         if: |
+          github.event_name != 'pull_request' &&
           !((github.event_name == 'issue_comment' && 
             (contains(github.event.comment.user.login, 'bot') || 
              github.event.comment.user.login == 'github-actions[bot]')) ||
@@ -67,10 +77,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: "openrouter"
         run: |
-          # 봇 실행 결과를 파일로 저장
+          # 봇 실행 결과를 저장
           output=$(npx autopr review-bot)
-          echo "$output" > review_output.txt
-          echo "::set-output name=review_output::$(cat review_output.txt)"
+          # 디버그 메시지 제거 (정규식 사용)
+          clean_output=$(echo "$output" | grep -v -E '^\[.*debug.*\]')
+          echo "review_output=$clean_output" >> $GITHUB_OUTPUT
 
       # issue_comment 이벤트인 경우 - 찾아서 업데이트 또는 새로 생성
       - name: Find Existing Comment for issue_comment
@@ -143,11 +154,3 @@ jobs:
 
             <!-- 리뷰 ID: ${{ github.event.review.id }} -->
           edit-mode: replace
-
-      # pull_request 이벤트인 경우 - 그냥 실행
-      - name: Run PR Review Bot Directly for pull_request events
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AI_PROVIDER: "openrouter"
-        run: npx autopr review-bot

--- a/src/cli/commands/review-bot.ts
+++ b/src/cli/commands/review-bot.ts
@@ -454,26 +454,34 @@ export async function reviewBotCommand(options: {
     if (event === "pull_request") {
       await handlePREvent(payload as PREvent, octokit);
     } else {
-      // 디버깅 목적으로 이벤트 타입 로깅
+      // 내부 로그는 디버그 로그로 남기고 (GitHub Actions 로그에만 표시)
       log.debug(
         `이벤트 타입: ${event} - GitHub Actions 워크플로우에서 처리됩니다.`,
       );
 
-      // stdout으로 출력 (GitHub Actions에서 사용 가능)
+      // 실제 응답 메시지 생성 (디버그 로그 없이 깔끔하게)
       if (
         event === "issue_comment" &&
         payload.issue &&
         payload.issue.pull_request
       ) {
-        console.log(`이슈 코멘트(#${payload.comment.id})에 대한 응답입니다.`);
-      } else if (event === "pull_request_review_comment") {
+        // 코멘트 작성자에게 응답
         console.log(
-          `PR 리뷰 코멘트(#${payload.comment.id})에 대한 응답입니다.`,
+          `@${payload.comment.user.login}님의 질문에 대한 답변입니다.`,
+        );
+      } else if (event === "pull_request_review_comment") {
+        // 코드 리뷰 코멘트 작성자에게 응답
+        console.log(
+          `${payload.comment.user.login}님의 코드 리뷰 코멘트에 대한 답변입니다.`,
         );
       } else if (event === "pull_request_review") {
-        console.log(`PR 리뷰(#${payload.review.id})에 대한 응답입니다.`);
+        // PR 리뷰 작성자에게 응답
+        console.log(`${payload.review.user.login}님의 리뷰에 대한 답변입니다.`);
       } else {
+        // 응답하지 않는 이벤트는 로그만 남김
         log.warn(t("commands.review_bot.warning.unsupported_event", { event }));
+        // 사용자에게는 빈 응답
+        console.log("");
       }
     }
   } catch (error) {


### PR DESCRIPTION
## 기능 설명
본 PR은 GitHub Actions 워크플로우 파일(`.github/workflows/pr-review.yml`)과 CLI 명령어 파일(`src/cli/commands/review-bot.ts`)을 수정하여 PR 리뷰 봇의 동작 방식을 개선합니다. 특히, 이벤트 유형에 따라 리뷰 봇의 실행 방식과 응답 생성 방식을 분리하여 효율성을 높이고, 디버깅 메시지를 제거하여 사용자 경험을 개선합니다.

## 구현 내용
- `.github/workflows/pr-review.yml`:
    - `pull_request` 이벤트에 대한 처리 방식을 분리하여 워크플로우를 간소화했습니다. 이제 `pull_request` 이벤트는 직접 `npx autopr review-bot`을 실행합니다.
    - `pull_request` 이벤트가 아닌 다른 이벤트 유형(issue_comment, pull_request_review 등)에 대해서는 봇 실행 결과를 저장하고, 디버그 메시지를 제거한 후 `GITHUB_OUTPUT`에 저장하도록 변경했습니다. 이는 봇의 응답을 후속 작업에서 활용하기 위함입니다.  `clean_output=$(echo "$output" | grep -v -E '^\[.*debug.*\]')` 명령어를 사용하여 디버그 메시지를 제거합니다.
    - 봇이 작성한 코멘트에 대한 응답을 방지하는 로직을 유지합니다.  `!((github.event_name == 'issue_comment' && (contains(github.event.comment.user.login, 'bot') || github.event.comment.user.login == 'github-actions[bot]')) || ...)` 조건문으로 이를 구현합니다.
- `src/cli/commands/review-bot.ts`:
    - 이벤트 유형에 따라 콘솔에 출력되는 메시지를 변경했습니다. `issue_comment`, `pull_request_review_comment`, `pull_request_review` 이벤트에 대해 각각 코멘트 또는 리뷰 작성자에게 응답하는 메시지를 출력합니다.  예: `@${payload.comment.user.login}님의 질문에 대한 답변입니다.`
    - 지원하지 않는 이벤트에 대해서는 경고 로그를 남기고 빈 응답을 출력하도록 변경했습니다.  `console.log("")`을 사용하여 빈 응답을 출력합니다.
    - 내부 로그는 디버그 로그로만 남도록 변경했습니다.

## 테스트
- [ ] GitHub Actions 워크플로우 변경에 대한 통합 테스트를 수행하여, 이벤트 유형에 따른 봇의 동작이 올바르게 분리되었는지 확인합니다.
- [ ] 다양한 이벤트 유형(issue_comment, pull_request_review_comment, pull_request_review 등)에 대해 봇이 올바른 응답 메시지를 생성하는지 확인하는 단위 테스트를 추가합니다.

## 영향 분석
- 기능 변경: PR 리뷰 봇이 이벤트 유형에 따라 다른 방식으로 동작하고, 응답 메시지가 개선되었습니다.
- 성능 영향: 디버그 메시지 제거를 통해 워크플로우 실행 속도가 약간 향상될 수 있습니다.
- 의존성 변경:  새로운 의존성은 추가되지 않았습니다.

## 체크리스트
- [ ] 코드가 컨벤션을 준수하나요?
- [ ] 성능에 영향을 주는 변경사항인가요? (미미한 향상)
- [ ] 문서화가 필요한 부분이 있나요? (코드 내 주석 업데이트)
