### PR TITLE
[FEATURE] 설정 초기화 및 AI 토큰 인증 기능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ src/utils/openrouter-provisioning.ts
 !CHANGELOG-kr.md
 !docs
 !docs/**
+.autopr.json

--- a/src/cli/commands/collaborator.ts
+++ b/src/cli/commands/collaborator.ts
@@ -72,7 +72,7 @@ export function createCollaboratorCommand(): Command {
         if (error instanceof Error) {
           log.error(error.message);
         } else {
-          log.error(t("common.error.unknown"), String(error));
+          log.error(t("common.error.unknown", { error }));
         }
         process.exit(1);
       }
@@ -120,7 +120,7 @@ export function createCollaboratorCommand(): Command {
           );
         }
       } catch (error) {
-        log.error(t("common.error.unknown"), String(error));
+        log.error(t("common.error.unknown", { error }));
         process.exit(1);
       }
     });
@@ -212,7 +212,7 @@ export function createCollaboratorCommand(): Command {
         if (error instanceof Error) {
           log.error(error.message);
         } else {
-          log.error(t("common.error.unknown"), String(error));
+          log.error(t("common.error.unknown", { error }));
         }
         process.exit(1);
       }
@@ -268,7 +268,7 @@ export function createCollaboratorCommand(): Command {
         if (error instanceof Error) {
           log.error(error.message);
         } else {
-          log.error(t("common.error.unknown"), String(error));
+          log.error(t("common.error.unknown", { error }));
         }
         process.exit(1);
       }
@@ -323,7 +323,7 @@ export function createCollaboratorCommand(): Command {
         if (error instanceof Error) {
           log.error(error.message);
         } else {
-          log.error(t("common.error.unknown"), String(error));
+          log.error(t("common.error.unknown", { error }));
         }
         process.exit(1);
       }

--- a/src/cli/commands/commit.ts
+++ b/src/cli/commands/commit.ts
@@ -482,7 +482,7 @@ export async function commitCommand(
       process.exit(1);
     }
   } catch (error) {
-    log.error(t("common.error.unknown"), error);
+    log.error(t("common.error.unknown", { error }));
     process.exit(1);
   }
 }

--- a/src/cli/commands/daily-report.ts
+++ b/src/cli/commands/daily-report.ts
@@ -695,7 +695,7 @@ export async function dailyReportCommand(
         break;
     }
   } catch (error) {
-    log.error(t("common.error.unknown"), error);
+    log.error(t("common.error.unknown", { error }));
     process.exit(1);
   }
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -5,38 +5,133 @@ import {
   loadGlobalConfig,
   loadProjectConfig,
   DEFAULT_PROJECT_CONFIG,
+  loadConfig,
 } from "../../core/config.js";
 import { setupGitHubAppCredentials } from "../../core/github-app.js";
 import { setupOAuthCredentials } from "../../core/oauth.js";
 import { log } from "../../utils/logger.js";
 import { existsSync, renameSync } from "fs";
 import { writeFile, appendFile, readFile } from "fs/promises";
+import { aiClient } from "../../core/ai-manager.js";
 
 export async function initCommand(): Promise<void> {
   try {
-    // 오버라이드: 기존 .autopr.json 파일이 있으면 백업 후 새로 생성
     const PROJECT_CONFIG_FILE = ".autopr.json";
+    let projectConfig = DEFAULT_PROJECT_CONFIG;
+
     if (existsSync(PROJECT_CONFIG_FILE)) {
-      const backupFile = PROJECT_CONFIG_FILE + ".bak";
-      renameSync(PROJECT_CONFIG_FILE, backupFile);
+      // 기존 설정 읽기
+      projectConfig = await loadProjectConfig();
+
+      // 인증 정보가 모두 있으면
+      if (
+        projectConfig.githubApp?.appId &&
+        projectConfig.githubApp?.clientId &&
+        projectConfig.githubApp?.installationId
+      ) {
+        const { doInit } = await inquirer.prompt([
+          {
+            type: "confirm",
+            name: "doInit",
+            message: t("commands.init.prompts.project_already_initialized", {
+              fallback:
+                "기존 설정이 있습니다. 초기화(백업 후 새로 생성) 하시겠습니까?",
+            }),
+            default: false,
+          },
+        ]);
+        if (doInit) {
+          // 백업 후 새로 생성
+          const backupFile = PROJECT_CONFIG_FILE + ".bak";
+          renameSync(PROJECT_CONFIG_FILE, backupFile);
+          await writeFile(
+            PROJECT_CONFIG_FILE,
+            JSON.stringify(DEFAULT_PROJECT_CONFIG, null, 2),
+          );
+          log.info(".autopr.json 파일이 백업되고, 새로 초기화되었습니다.");
+          projectConfig = DEFAULT_PROJECT_CONFIG;
+        } else {
+          log.info("기존 설정을 유지합니다.");
+        }
+      } else {
+        // 인증 정보가 없으면 무조건 백업 후 새로 생성
+        const backupFile = PROJECT_CONFIG_FILE + ".bak";
+        renameSync(PROJECT_CONFIG_FILE, backupFile);
+        await writeFile(
+          PROJECT_CONFIG_FILE,
+          JSON.stringify(DEFAULT_PROJECT_CONFIG, null, 2),
+        );
+        log.info(".autopr.json 파일이 백업되고, 새로 초기화되었습니다.");
+        projectConfig = DEFAULT_PROJECT_CONFIG;
+      }
+    } else {
+      // 파일이 없으면 새로 생성
       await writeFile(
         PROJECT_CONFIG_FILE,
         JSON.stringify(DEFAULT_PROJECT_CONFIG, null, 2),
       );
-      log.info(".autopr.json 파일이 백업되고, 새로 초기화되었습니다.");
+      projectConfig = DEFAULT_PROJECT_CONFIG;
     }
 
-    // 1. GitHub App 인증 (필수)
-    try {
-      await setupGitHubAppCredentials();
-      log.info(t("commands.init.info.github_app_auth_success"));
-    } catch (error) {
-      log.error(t("commands.init.error.auth_failed", { error }));
-      process.exit(1);
-    }
-
-    // 2. 유저 OAuth 인증 (선택/권장)
+    // config는 항상 최신값으로 불러옴
+    const config = await loadConfig();
     const globalConfig = await loadGlobalConfig();
+    let needGithubAppAuth = true;
+
+    // GitHub App 설정값이 모두 있는지 확인 (projectConfig 기준)
+    if (
+      projectConfig.githubApp?.appId &&
+      projectConfig.githubApp?.clientId &&
+      projectConfig.githubApp?.installationId
+    ) {
+      // 이미 GitHub App이 인증된 경우 재인증 여부 묻기
+      const { reauth } = await inquirer.prompt([
+        {
+          type: "confirm",
+          name: "reauth",
+          message: t("commands.init.prompts.github_app_already_authenticated", {
+            fallback:
+              "GitHub App이 이미 인증되어 있습니다. 다시 인증하시겠습니까?",
+          }),
+          default: false,
+        },
+      ]);
+      needGithubAppAuth = reauth;
+    }
+
+    // GitHub App 인증 (필요한 경우에만)
+    if (needGithubAppAuth) {
+      try {
+        await setupGitHubAppCredentials();
+        log.info(t("commands.init.info.github_app_auth_success"));
+      } catch (error) {
+        log.error(t("commands.init.error.auth_failed", { error }));
+        process.exit(1);
+      }
+    } else {
+      log.info(
+        t("commands.init.info.github_app_auth_skipped", {
+          fallback: "GitHub App 인증을 건너뛰었습니다.",
+        }),
+      );
+    }
+
+    // 2. AI API JWT 토큰 발급 (누구나 가능)
+    try {
+      log.info(t("commands.init.info.acquiring_ai_token"));
+      const tokenSuccess = await aiClient.getAuthToken();
+      if (tokenSuccess) {
+        log.info(t("commands.init.info.ai_token_success"));
+      } else {
+        log.warn(t("commands.init.warning.ai_token_failed"));
+        log.warn(t("commands.init.warning.ai_features_unavailable"));
+      }
+    } catch (error) {
+      log.warn(t("commands.init.warning.ai_token_error"), error);
+      log.warn(t("commands.init.warning.ai_features_unavailable"));
+    }
+
+    // 4. 유저 OAuth 인증 (선택/권장)
     let needOAuth = true;
     if (globalConfig.githubToken) {
       // 이미 인증된 경우
@@ -110,7 +205,6 @@ export async function initCommand(): Promise<void> {
     }
 
     // 프로젝트 설정
-    const projectConfig = await loadProjectConfig();
     const projectAnswers = await inquirer.prompt([
       {
         type: "input",
@@ -150,13 +244,14 @@ export async function initCommand(): Promise<void> {
         log.info(".autopr.json이 .gitignore에 추가되었습니다.");
       }
 
+      // 설정 완료 후 안내
       log.info(t("common.success.init"));
     } catch (error) {
-      log.error(t("common.error.unknown"), error);
+      log.error(t("common.error.unknown", { error }));
       process.exit(1);
     }
   } catch (error) {
-    log.error(t("common.error.unknown"), error);
+    log.error(t("common.error.unknown", { error }));
     process.exit(1);
   }
 }

--- a/src/cli/commands/lang.ts
+++ b/src/cli/commands/lang.ts
@@ -28,7 +28,7 @@ export function createLangCommand(): Command {
         await setLanguage(language);
         log.info(t("commands.lang.success.changed", { language }));
       } catch (error) {
-        log.error(t("common.error.unknown"), error);
+        log.error(t("common.error.unknown", { error }));
         process.exit(1);
       }
     });
@@ -45,7 +45,7 @@ export function createLangCommand(): Command {
           }),
         );
       } catch (error) {
-        log.error(t("common.error.unknown"), error);
+        log.error(t("common.error.unknown", { error }));
         process.exit(1);
       }
     });

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -372,7 +372,7 @@ export async function listCommand(): Promise<void> {
         break;
     }
   } catch (error) {
-    log.error(t("common.error.unknown"), error);
+    log.error(t("common.error.unknown", { error }));
     process.exit(1);
   }
 }

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -571,16 +571,14 @@ export async function mergeCommand(prNumber: string): Promise<void> {
 
       log.info(t("commands.merge.cleanup.complete"));
     } catch (error) {
-      log.warn(
-        t("commands.merge.error.cleanup_failed", { error: String(error) }),
-      );
+      log.warn(t("commands.merge.error.cleanup_failed", { error }));
       log.warn(t("commands.merge.error.manual_cleanup"));
     }
   } catch (error) {
     if (error instanceof Error) {
       log.error(error.message);
     } else {
-      log.error(t("common.error.unknown"), String(error));
+      log.error(t("common.error.unknown", { error }));
     }
     process.exit(1);
   }

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -1066,7 +1066,7 @@ export async function newCommand(): Promise<void> {
     }
     return;
   } catch (error) {
-    log.error(t("common.error.unknown"), error);
+    log.error(t("common.error.unknown", { error }));
     process.exit(1);
   }
 }

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -929,6 +929,9 @@ export async function newCommand(): Promise<void> {
       repo: repoInfo.repo,
       head: `${repoInfo.owner}:${headBranch}`,
       state: "open",
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
     });
 
     // PR 본문 설정 (AI 생성)

--- a/src/cli/commands/reopen.ts
+++ b/src/cli/commands/reopen.ts
@@ -58,7 +58,7 @@ export async function reopenCommand(prNumber: string): Promise<void> {
     if (error instanceof Error) {
       log.error(error.message);
     } else {
-      log.error(t("common.error.unknown"), String(error));
+      log.error(t("common.error.unknown", { error }));
     }
     process.exit(1);
   }

--- a/src/cli/commands/reviewer-group.ts
+++ b/src/cli/commands/reviewer-group.ts
@@ -51,7 +51,7 @@ export function createReviewerGroupCommand(): Command {
 
           log.info(t("commands.reviewer_group.add.success", { name }));
         } catch (error) {
-          log.error(t("common.error.unknown"), String(error));
+          log.error(t("common.error.unknown", { error }));
           process.exit(1);
         }
       },
@@ -80,7 +80,7 @@ export function createReviewerGroupCommand(): Command {
 
         log.info(t("commands.reviewer_group.remove.success", { name }));
       } catch (error) {
-        log.error(t("common.error.unknown"), String(error));
+        log.error(t("common.error.unknown", { error }));
         process.exit(1);
       }
     });
@@ -133,7 +133,7 @@ export function createReviewerGroupCommand(): Command {
 
           log.info(t("commands.reviewer_group.update.success", { name }));
         } catch (error) {
-          log.error(t("common.error.unknown"), String(error));
+          log.error(t("common.error.unknown", { error }));
           process.exit(1);
         }
       },
@@ -162,7 +162,7 @@ export function createReviewerGroupCommand(): Command {
           );
         }
       } catch (error) {
-        log.error(t("common.error.unknown"), String(error));
+        log.error(t("common.error.unknown", { error }));
         process.exit(1);
       }
     });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -143,7 +143,7 @@ export async function updateCommand(prNumber: string): Promise<void> {
       process.exit(1);
     }
   } catch (error: any) {
-    log.error(t("common.error.unknown"), error.message);
+    log.error(t("common.error.unknown", { error }));
     if (error.response) {
       log.error("API Response:", JSON.stringify(error.response.data, null, 2));
     }

--- a/src/core/ai-manager.ts
+++ b/src/core/ai-manager.ts
@@ -27,12 +27,12 @@ interface APIResponse<T = any> {
 export class AIClient {
   private baseUrl: string;
 
-  constructor(baseUrl: string = "https://api.newextend.com/api") {
-    this.baseUrl = baseUrl;
-  }
-  // constructor(baseUrl: string = "http://localhost:4000/api") {
+  // constructor(baseUrl: string = "https://api.newextend.com/api") {
   //   this.baseUrl = baseUrl;
   // }
+  constructor(baseUrl: string = "http://localhost:4000/api") {
+    this.baseUrl = baseUrl;
+  }
 
   /**
    * API 엔드포인트를 호출합니다.

--- a/src/core/ai-manager.ts
+++ b/src/core/ai-manager.ts
@@ -1,15 +1,37 @@
 import { createFetch } from "next-type-fetch";
 import { log } from "../utils/logger.js";
 import { t } from "../i18n/index.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+// 설정 및 토큰 저장 경로
+const CONFIG_DIR = path.join(os.homedir(), ".autopr");
+const TOKEN_FILE = path.join(CONFIG_DIR, "token.json");
+
+// 토큰 인터페이스
+interface TokenData {
+  token: string;
+  expiresAt: number; // UNIX timestamp (milliseconds)
+}
 
 // 기본 fetch 인스턴스 생성
-const fetch = createFetch({
-  headers: {
+const createClient = (token?: string) => {
+  const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "x-ai-api-key": "EnnVP5DatEta2Tv6D0nklXEB",
     "x-title": "github-autopr",
-  },
-});
+  };
+
+  // JWT 토큰이 있을 때만 x-ai-api-key 헤더 설정
+  if (token) {
+    headers["x-ai-api-key"] = token;
+  }
+
+  return createFetch({ headers });
+};
+
+// 초기 기본 클라이언트 (토큰 없이)
+let fetch = createClient();
 
 // 서버 응답 타입 정의
 interface APIResponse<T = any> {
@@ -26,12 +48,101 @@ interface APIResponse<T = any> {
  */
 export class AIClient {
   private baseUrl: string;
+  private tokenData: TokenData | null = null;
 
-  // constructor(baseUrl: string = "https://api.newextend.com/api") {
-  //   this.baseUrl = baseUrl;
-  // }
   constructor(baseUrl: string = "http://localhost:4000/api") {
     this.baseUrl = baseUrl;
+    this.loadToken();
+  }
+
+  /**
+   * 토큰 파일에서 JWT 토큰을 로드합니다.
+   */
+  private loadToken(): void {
+    try {
+      if (fs.existsSync(TOKEN_FILE)) {
+        const data = JSON.parse(fs.readFileSync(TOKEN_FILE, "utf-8"));
+
+        // 토큰 유효성 검증 (만료 여부)
+        if (data && data.token && data.expiresAt > Date.now()) {
+          this.tokenData = data;
+          // 토큰으로 fetch 클라이언트 재생성
+          fetch = createClient(data.token);
+          log.debug(t("core.ai_manager.info.token_loaded"));
+        } else {
+          log.debug(t("core.ai_manager.info.token_expired"));
+          this.tokenData = null;
+          fetch = createClient(); // 토큰 없는 클라이언트로 초기화
+        }
+      }
+    } catch (error) {
+      log.error(t("core.ai_manager.error.token_load_failed"), error);
+      this.tokenData = null;
+      fetch = createClient(); // 오류 시 토큰 없는 클라이언트로 초기화
+    }
+  }
+
+  /**
+   * 토큰을 파일에 저장합니다.
+   */
+  private saveToken(tokenData: TokenData): void {
+    try {
+      // 디렉토리가 없으면 생성
+      if (!fs.existsSync(CONFIG_DIR)) {
+        fs.mkdirSync(CONFIG_DIR, { recursive: true });
+      }
+
+      fs.writeFileSync(TOKEN_FILE, JSON.stringify(tokenData, null, 2), "utf-8");
+
+      log.debug(t("core.ai_manager.info.token_saved"));
+    } catch (error) {
+      log.error(t("core.ai_manager.error.token_save_failed"), error);
+    }
+  }
+
+  /**
+   * 서버에서 JWT 토큰을 발급받습니다.
+   * @param title 클라이언트 식별용 타이틀
+   */
+  public async getAuthToken(title: string = "github-autopr"): Promise<boolean> {
+    try {
+      // 이미 유효한 토큰이 있으면 스킵
+      if (this.tokenData && this.tokenData.expiresAt > Date.now()) {
+        return true;
+      }
+
+      // 기본 클라이언트로 토큰 요청 (토큰 없음)
+      const tempClient = createClient();
+      const response = await tempClient.post<
+        APIResponse<{ token: string; expiresIn: number }>
+      >(`${this.baseUrl}/ai/google/auth/token`, {
+        title,
+      });
+
+      if (response.data?.success && response.data?.data?.token) {
+        const { token, expiresIn } = response.data.data;
+
+        // 토큰 데이터 저장 (만료시간은 현재시간 + expiresIn초)
+        this.tokenData = {
+          token,
+          expiresAt: Date.now() + expiresIn * 1000,
+        };
+
+        // 토큰 파일에 저장
+        this.saveToken(this.tokenData);
+
+        // 새 토큰으로 fetch 클라이언트 업데이트
+        fetch = createClient(token);
+
+        log.info(t("core.ai_manager.info.token_acquired"));
+        return true;
+      }
+
+      return false;
+    } catch (error) {
+      log.error(t("core.ai_manager.error.token_acquisition_failed"), error);
+      return false;
+    }
   }
 
   /**
@@ -42,20 +153,47 @@ export class AIClient {
    */
   public async callAPI<T>(endpoint: string, data: any): Promise<T> {
     try {
-      const response = await fetch.post<APIResponse<T>>(
-        `${this.baseUrl}${endpoint}`,
-        data,
-      );
-
-      // 서버 응답 구조 처리
-      // 서버는 { success, statusCode, message, data: { 실제 데이터 }, error } 형식으로 응답
-      if (response.data && response.data.data) {
-        return response.data.data;
+      // API 호출 전에 토큰 유효성 확인 및 필요시 갱신
+      const tokenValid = await this.ensureValidToken();
+      if (!tokenValid) {
+        log.error(t("core.ai_manager.error.no_valid_token"));
+        throw new Error(t("core.ai_manager.error.authentication_required"));
       }
 
-      return response.data as unknown as T;
+      // 토큰 정보 로깅 (테스트용)
+      if (this.tokenData) {
+        const timeToExpiry = this.tokenData.expiresAt - Date.now();
+        log.info(
+          `API 호출 (${endpoint}) - 토큰 만료까지 ${Math.round(timeToExpiry / 1000)}초 남음`,
+        );
+      }
+
+      return await this.executeRequest<T>(endpoint, data);
     } catch (error) {
-      process.stdout.write(JSON.stringify(error, null, 2));
+      // 인증 오류(401)인 경우 토큰 갱신 시도 후 재시도
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        ((error as any).status === 401 ||
+          (error as any).statusCode === 401 ||
+          (error as Error).message?.includes("401"))
+      ) {
+        log.warn(t("core.ai_manager.warning.token_expired_retrying"));
+        // 토큰 강제 만료 처리
+        if (this.tokenData) {
+          this.tokenData.expiresAt = 0;
+        }
+
+        // 토큰 새로 발급 시도
+        const tokenRefreshed = await this.getAuthToken();
+        if (tokenRefreshed) {
+          log.info(t("core.ai_manager.info.token_refreshed_retrying"));
+          // 토큰 갱신 성공 시 원래 요청 다시 시도
+          return await this.executeRequest<T>(endpoint, data);
+        }
+      }
+
+      // 다른 오류이거나 토큰 갱신 실패 시
       log.error(
         t("core.ai_manager.error.api_call_failed", { endpoint }),
         error,
@@ -72,6 +210,47 @@ export class AIClient {
   }
 
   /**
+   * 실제 API 요청을 실행합니다. (토큰 갱신 로직에서 재사용)
+   */
+  private async executeRequest<T>(endpoint: string, data: any): Promise<T> {
+    const response = await fetch.post<APIResponse<T>>(
+      `${this.baseUrl}${endpoint}`,
+      data,
+    );
+
+    // 서버 응답 구조 처리
+    if (response.data && response.data.data) {
+      return response.data.data;
+    }
+
+    return response.data as unknown as T;
+  }
+
+  /**
+   * 토큰이 유효한지 확인하고, 필요한 경우 갱신합니다.
+   * @returns 유효한 토큰이 있으면 true, 없으면 false
+   */
+  private async ensureValidToken(): Promise<boolean> {
+    const TEN_SECONDS = 10 * 1000; // 테스트용 - 10초 전에 만료되면 갱신
+
+    // 토큰이 없거나 곧 만료되면 갱신
+    if (!this.tokenData) {
+      log.debug(t("core.ai_manager.info.no_token"));
+      return await this.getAuthToken();
+    }
+
+    const timeToExpiry = this.tokenData.expiresAt - Date.now();
+    log.debug(`토큰 만료까지 남은 시간: ${Math.round(timeToExpiry / 1000)}초`);
+
+    if (timeToExpiry < TEN_SECONDS) {
+      log.debug(t("core.ai_manager.info.token_expiring_soon"));
+      return await this.getAuthToken();
+    }
+
+    return true;
+  }
+
+  /**
    * GitHub App 기본 정보를 가져옵니다.
    * @returns GitHub App 정보 (appId, clientId)
    */
@@ -80,6 +259,12 @@ export class AIClient {
     clientId: string;
   }> {
     try {
+      // API 호출 전에 토큰 유효성 확인
+      const tokenValid = await this.ensureValidToken();
+      if (!tokenValid) {
+        throw new Error(t("core.ai_manager.error.authentication_required"));
+      }
+
       const response = await fetch.get<
         APIResponse<{ appId: string; clientId: string }>
       >(`${this.baseUrl}/github/app-info`);
@@ -91,6 +276,25 @@ export class AIClient {
 
       throw new Error(t("core.ai_manager.error.github_app_info_missing"));
     } catch (error) {
+      // 인증 오류(401)인 경우 토큰 갱신 시도 후 재시도
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        ((error as any).status === 401 ||
+          (error as any).statusCode === 401 ||
+          (error as Error).message?.includes("401"))
+      ) {
+        // 토큰 강제 만료 처리 및 갱신
+        if (this.tokenData) {
+          this.tokenData.expiresAt = 0;
+        }
+        const tokenRefreshed = await this.getAuthToken();
+        if (tokenRefreshed) {
+          // 토큰 갱신 성공 시 원래 요청 다시 시도
+          return await this.getGitHubAppInfo();
+        }
+      }
+
       log.error(t("core.ai_manager.error.github_app_info_failed"), error);
       throw new Error(
         t("core.ai_manager.error.github_app_info_error", {
@@ -110,6 +314,12 @@ export class AIClient {
    */
   public async getGitHubAppToken(installationId: number): Promise<string> {
     try {
+      // API 호출 전에 토큰 유효성 확인
+      const tokenValid = await this.ensureValidToken();
+      if (!tokenValid) {
+        throw new Error(t("core.ai_manager.error.authentication_required"));
+      }
+
       const response = await fetch.get<APIResponse<{ token: string }>>(
         `${this.baseUrl}/github/app-token/${installationId}`,
       );
@@ -121,6 +331,25 @@ export class AIClient {
 
       throw new Error(t("core.ai_manager.error.token_missing"));
     } catch (error) {
+      // 인증 오류(401)인 경우 토큰 갱신 시도 후 재시도
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        ((error as any).status === 401 ||
+          (error as any).statusCode === 401 ||
+          (error as Error).message?.includes("401"))
+      ) {
+        // 토큰 강제 만료 처리 및 갱신
+        if (this.tokenData) {
+          this.tokenData.expiresAt = 0;
+        }
+        const tokenRefreshed = await this.getAuthToken();
+        if (tokenRefreshed) {
+          // 토큰 갱신 성공 시 원래 요청 다시 시도
+          return await this.getGitHubAppToken(installationId);
+        }
+      }
+
       log.error(t("core.ai_manager.error.app_token_failed"), error);
       throw new Error(
         t("core.ai_manager.error.app_token_error", {
@@ -139,6 +368,12 @@ export class AIClient {
    */
   public async getGitHubAppInstallations<T>(): Promise<T> {
     try {
+      // API 호출 전에 토큰 유효성 확인
+      const tokenValid = await this.ensureValidToken();
+      if (!tokenValid) {
+        throw new Error(t("core.ai_manager.error.authentication_required"));
+      }
+
       const response = await fetch.get<APIResponse<T>>(
         `${this.baseUrl}/github/app-installations`,
       );
@@ -150,6 +385,25 @@ export class AIClient {
 
       throw new Error(t("core.ai_manager.error.installations_missing"));
     } catch (error) {
+      // 인증 오류(401)인 경우 토큰 갱신 시도 후 재시도
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        ((error as any).status === 401 ||
+          (error as any).statusCode === 401 ||
+          (error as Error).message?.includes("401"))
+      ) {
+        // 토큰 강제 만료 처리 및 갱신
+        if (this.tokenData) {
+          this.tokenData.expiresAt = 0;
+        }
+        const tokenRefreshed = await this.getAuthToken();
+        if (tokenRefreshed) {
+          // 토큰 갱신 성공 시 원래 요청 다시 시도
+          return await this.getGitHubAppInstallations<T>();
+        }
+      }
+
       log.error(t("core.ai_manager.error.installations_failed"), error);
       throw new Error(
         t("core.ai_manager.error.installations_error", {
@@ -168,6 +422,12 @@ export class AIClient {
    */
   public async getGitHubOAuthClientInfo(): Promise<{ oauthClientId: string }> {
     try {
+      // API 호출 전에 토큰 유효성 확인
+      const tokenValid = await this.ensureValidToken();
+      if (!tokenValid) {
+        throw new Error(t("core.ai_manager.error.authentication_required"));
+      }
+
       const response = await fetch.get<APIResponse<{ oauthClientId: string }>>(
         `${this.baseUrl}/github/oauth-client-info`,
       );
@@ -176,6 +436,25 @@ export class AIClient {
       }
       throw new Error(t("core.ai_manager.error.oauth_client_info_missing"));
     } catch (error) {
+      // 인증 오류(401)인 경우 토큰 갱신 시도 후 재시도
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        ((error as any).status === 401 ||
+          (error as any).statusCode === 401 ||
+          (error as Error).message?.includes("401"))
+      ) {
+        // 토큰 강제 만료 처리 및 갱신
+        if (this.tokenData) {
+          this.tokenData.expiresAt = 0;
+        }
+        const tokenRefreshed = await this.getAuthToken();
+        if (tokenRefreshed) {
+          // 토큰 갱신 성공 시 원래 요청 다시 시도
+          return await this.getGitHubOAuthClientInfo();
+        }
+      }
+
       log.error(t("core.ai_manager.error.oauth_client_info_failed"), error);
       throw new Error(
         t("core.ai_manager.error.oauth_client_info_error", {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -21,14 +21,14 @@ const PROJECT_CONFIG_FILE = ".autopr.json";
 const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   githubToken: "",
   language: "en",
+};
+
+export const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   githubApp: {
     appId: "",
     clientId: "",
     installationId: 0,
   },
-};
-
-export const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   defaultReviewers: [],
   reviewerGroups: [],
   branchPatterns: [
@@ -208,14 +208,12 @@ export async function updateProjectConfig(
   return validatedConfig;
 }
 
-// updateConfig
 export async function updateConfig(updates: Partial<Config>): Promise<Config> {
-  const { githubToken, language, githubApp, ...projectUpdates } = updates;
+  const { githubToken, language, ...projectUpdates } = updates;
 
   const globalUpdates: Partial<GlobalConfig> = {
     ...(githubToken && { githubToken }),
     ...(language && { language }),
-    ...(githubApp !== undefined && { githubApp }),
   };
 
   if (Object.keys(globalUpdates).length > 0) {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -145,7 +145,7 @@ export const setLanguage = async (language: string): Promise<void> => {
   await i18next.changeLanguage(language);
 };
 
-export const t = i18next.t.bind(i18next);
+export const t = (...args: Parameters<typeof i18next.t>) => i18next.t(...args);
 
 export const supportedLanguages = ["en", "ko"] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];

--- a/src/i18n/locales/en/commands/init.json
+++ b/src/i18n/locales/en/commands/init.json
@@ -11,7 +11,8 @@
     "oauth_auth_success": "GitHub user authentication completed successfully."
   },
   "error": {
-    "invalid_token": "Invalid GitHub token"
+    "invalid_token": "Invalid GitHub token",
+    "auth_failed": "GitHub App authentication failed: {{error}}"
   },
   "prompts": {
     "update_token": "A GitHub token is already configured. Update it?",

--- a/src/i18n/locales/en/core/ai-manager.json
+++ b/src/i18n/locales/en/core/ai-manager.json
@@ -1,4 +1,13 @@
 {
+  "info": {
+    "no_token": "No token found. Requesting a new token...",
+    "token_expiring_soon": "Token is about to expire. Refreshing...",
+    "token_acquired": "Token acquired successfully.",
+    "token_refreshed_retrying": "Token refreshed. Retrying request..."
+  },
+  "warning": {
+    "token_expired_retrying": "Token expired. Refreshing and retrying..."
+  },
   "error": {
     "api_call_failed": "API call failed ({{endpoint}})",
     "api_call_error": "API call failed: {{message}}",
@@ -14,6 +23,9 @@
     "installations_error": "Failed to get GitHub App installations list: {{message}}",
     "oauth_client_info_failed": "Failed to get GitHub OAuth client info",
     "oauth_client_info_error": "Failed to get GitHub OAuth client info: {{message}}",
-    "oauth_client_info_missing": "GitHub OAuth client info is missing"
+    "oauth_client_info_missing": "GitHub OAuth client info is missing",
+    "no_valid_token": "No valid token available.",
+    "authentication_required": "Authentication required. Please re-initialize or check your token.",
+    "token_acquisition_failed": "Failed to acquire token: {{error}}"
   }
 }

--- a/src/i18n/locales/en/core/config.json
+++ b/src/i18n/locales/en/core/config.json
@@ -4,7 +4,7 @@
     "load_project_failed": "Failed to load project configuration: {{error}}",
     "save_global_failed": "Failed to save global configuration: {{error}}",
     "save_project_failed": "Failed to save project configuration: {{error}}",
-    "auto_override_notice": "The .autopr.json file was incompatible and has been automatically reset to default. The previous file was backed up as .bak.",
-    "global_invalid_notice": "The global configuration is incompatible. Please run 'autopr init' to reinitialize."
+    "auto_override_notice": "The .autopr.json file was incompatible and has been automatically reset to default (including githubApp info). The previous file was backed up as .bak.",
+    "global_invalid_notice": "The global configuration is incompatible. Please run 'autopr init' to reinitialize. (githubApp info is now per-project)"
   }
 }

--- a/src/i18n/locales/ko/commands/init.json
+++ b/src/i18n/locales/ko/commands/init.json
@@ -8,7 +8,10 @@
     "production_branch_set": "프로덕션 브랜치 설정: {{branch}}",
     "development_branch_set": "개발 브랜치 설정: {{branch}}",
     "github_app_auth_success": "GitHub App 인증이 완료되었습니다. 서버를 통해 자동 인증됩니다.",
-    "oauth_auth_success": "GitHub 사용자 인증이 성공적으로 완료되었습니다."
+    "oauth_auth_success": "GitHub 사용자 인증이 성공적으로 완료되었습니다.",
+    "github_app_auth_skipped": "GitHub App 인증을 건너뛰었습니다.",
+    "acquiring_ai_token": "AI API 토큰을 발급받는 중입니다...",
+    "ai_token_success": "AI API 토큰 발급에 성공했습니다."
   },
   "error": {
     "invalid_token": "유효하지 않은 GitHub 토큰입니다",
@@ -29,9 +32,22 @@
     "development_branch": "개발 브랜치:",
     "reviewers": "기본 리뷰어 (쉼표로 구분):",
     "oauth_authenticate": "PR 생성을 위해 GitHub 사용자 계정으로 인증하시겠습니까?",
-    "oauth_already_authenticated": "GitHub 사용자 토큰이 이미 등록되어 있습니다. 다시 인증하시겠습니까?"
+    "oauth_already_authenticated": "GitHub 사용자 토큰이 이미 등록되어 있습니다. 다시 인증하시겠습니까?",
+    "project_already_initialized": "기존 설정이 있습니다. 초기화(백업 후 새로 생성) 하시겠습니까?",
+    "github_app_already_authenticated": "GitHub App이 이미 인증되어 있습니다. 다시 인증하시겠습니까?"
   },
   "warning": {
-    "oauth_auth_failed": "GitHub 사용자 인증에 실패했습니다."
+    "oauth_auth_failed": "GitHub 사용자 인증에 실패했습니다.",
+    "ai_token_failed": "AI API 토큰 발급에 실패했습니다.",
+    "ai_features_unavailable": "AI 관련 기능을 사용할 수 없습니다.",
+    "ai_token_error": "AI API 토큰 발급 중 오류가 발생했습니다."
+  },
+  "common": {
+    "success": {
+      "init": "설정이 성공적으로 완료되었습니다."
+    },
+    "error": {
+      "unknown": "알 수 없는 오류가 발생했습니다."
+    }
   }
 }

--- a/src/i18n/locales/ko/commands/init.json
+++ b/src/i18n/locales/ko/commands/init.json
@@ -11,7 +11,8 @@
     "oauth_auth_success": "GitHub 사용자 인증이 성공적으로 완료되었습니다."
   },
   "error": {
-    "invalid_token": "유효하지 않은 GitHub 토큰입니다"
+    "invalid_token": "유효하지 않은 GitHub 토큰입니다",
+    "auth_failed": "GitHub App 인증에 실패했습니다: {{error}}"
   },
   "prompts": {
     "update_token": "GitHub 토큰이 이미 설정되어 있습니다. 업데이트하시겠습니까?",

--- a/src/i18n/locales/ko/core/ai-manager.json
+++ b/src/i18n/locales/ko/core/ai-manager.json
@@ -1,5 +1,17 @@
 {
+  "info": {
+    "no_token": "토큰이 없습니다. 새 토큰을 요청합니다...",
+    "token_expiring_soon": "토큰이 곧 만료됩니다. 갱신 중...",
+    "token_acquired": "토큰을 성공적으로 획득했습니다.",
+    "token_refreshed_retrying": "토큰이 갱신되었습니다. 요청을 재시도합니다..."
+  },
+  "warning": {
+    "token_expired_retrying": "토큰이 만료되었습니다. 갱신 후 재시도합니다..."
+  },
   "error": {
+    "no_valid_token": "유효한 토큰이 없습니다.",
+    "authentication_required": "인증이 필요합니다. 다시 초기화하거나 토큰을 확인하세요.",
+    "token_acquisition_failed": "토큰 획득에 실패했습니다: {{error}}",
     "api_call_failed": "API 호출 실패 ({{endpoint}})",
     "api_call_error": "API 호출 실패: {{message}}",
     "unknown_error": "알 수 없는 오류",

--- a/src/i18n/locales/ko/core/config.json
+++ b/src/i18n/locales/ko/core/config.json
@@ -4,7 +4,7 @@
     "load_project_failed": "프로젝트 설정을 불러오는 데 실패했습니다: {{error}}",
     "save_global_failed": "전역 설정을 저장하는 데 실패했습니다: {{error}}",
     "save_project_failed": "프로젝트 설정을 저장하는 데 실패했습니다: {{error}}",
-    "auto_override_notice": ".autopr.json 파일이 호환되지 않아 자동으로 초기화되었습니다. 기존 파일은 .bak으로 백업되었습니다.",
-    "global_invalid_notice": "전역 설정 파일이 호환되지 않습니다. 'autopr init'을 실행해 초기화해 주세요."
+    "auto_override_notice": ".autopr.json 파일이 호환되지 않아 githubApp 정보까지 포함해 자동으로 초기화되었습니다. 기존 파일은 .bak으로 백업되었습니다.",
+    "global_invalid_notice": "전역 설정 파일이 호환되지 않습니다. 'autopr init'을 실행해 초기화해 주세요. (githubApp 정보는 이제 프로젝트별로 관리됩니다)"
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -44,14 +44,12 @@ export const GlobalConfigSchema = z.object({
 
   // 언어 설정
   language: z.enum(supportedLanguages).default("en"),
-
-  // GitHub App 설정
-  githubApp: GitHubAppConfigSchema,
 });
 
 export const ProjectConfigSchema = z.object({
   owner: z.string().optional(),
   repo: z.string().optional(),
+  githubApp: GitHubAppConfigSchema,
   defaultReviewers: z.array(z.string()).default([]),
   reviewerGroups: z.array(ReviewerGroupSchema).default([]),
   branchPatterns: z.array(BranchPatternSchema).default([]),


### PR DESCRIPTION
# 초기화 기능 개선 및 AI API 연동 추가

초기화 명령어 개선 및 AI API 연동 관련 기능 추가, GitHub API 버전 지정, 로깅 개선, 설정 파일 관련 문제 해결 및 사용자 경험 개선.

- `init` 명령어의 GitHub App 인증 로직 개선 및 AI API JWT 토큰 발급 기능 추가
- GitHub API 요청 시 `X-GitHub-Api-Version` 헤더를 명시적으로 설정
- 오류 메시지 및 로깅 개선
- 설정 파일 처리 관련 문제 해결 및 사용자 경험 개선

## 주요 코드 구현사항
- `.gitignore` 파일에 `.autopr.json` 추가하여 git 추적에서 제외
- `src/cli/commands/init.ts` 수정:
-    - GitHub App 인증 로직 개선: 기존 설정 존재 시 재인증 여부 확인, 인증 정보 없을 시 백업 후 초기화
-    - AI API JWT 토큰 발급 기능 추가: `aiClient.getAuthToken()` 호출하여 토큰 획득 및 저장
-    - 설정 저장 로직 변경: `githubApp` 설정을 별도로 저장하지 않고, 프로젝트 설정 업데이트 시 함께 저장
-    - `.autopr.json` 파일이 `.gitignore`에 자동 추가되도록 로직 추가
- `src/core/ai-manager.ts` 수정:
-    - AI API 연동을 위한 `AIClient` 클래스 도입: JWT 토큰 관리, API 호출 기능 구현
-    - 토큰 저장 및 로딩 로직 구현: 파일 시스템을 통해 토큰을 저장하고 로드
-    - API 호출 시 토큰 갱신 로직 추가: 만료된 토큰 갱신 및 재시도
- `src/core/config.ts` 수정: githubApp 설정 global config 에서 분리
- `src/core/github.ts` 수정: GitHub API 요청 시 `X-GitHub-Api-Version: 2022-11-28` 헤더 추가
- `src/i18n/index.ts` 수정: i18next 타입 관련 오류 수정
- 전체 코드에서 오류 로깅 및 메시지 개선: `t("common.error.unknown", { error })` 패턴 적용
- GitHub API 버전을 명시적으로 지정: 2022-11-28
- 프로젝트 설정에 GitHub App 관련 정보가 포함되도록 변경

## Release Note
`.autopr.json` 파일에 GitHub App 정보가 저장되도록 변경되었습니다. 따라서 `.autopr.json` 파일을 커밋하지 않도록 `.gitignore`에 `.autopr.json`을 추가하는 것이 좋습니다. `autopr init` 명령어를 통해 GitHub App 인증 및 AI API 토큰 발급을 진행해야 합니다. GitHub App 인증 정보는 프로젝트별로 관리됩니다. 기존 global config의 githubApp 정보는 더이상 사용되지 않습니다. 별도의 마이그레이션/배포 작업은 필요하지 않습니다.

**Keywords:** 초기화, GitHub App, AI API, 인증, 설정, GitHub API 버전, 로깅, 리팩토링

> _Reason: init 명령어 개선 및 AI API 연동, GitHub API 버전 지정, 로깅 개선, 설정 파일 관련 문제 해결 및 사용자 경험 개선 사항을 반영하는 제목과 설명입니다._