### PR TITLE
[REFACTOR] feat: 원격 브랜치 존재 확인 및 푸시 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newexpand-autopr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GitHub PR Automation CLI Tool with AI",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,7 +27,7 @@ async function main() {
     program
       .name("autopr")
       .description(t("commands.index.program.description"))
-      .version("1.0.1");
+      .version("1.0.2");
 
     // 기본 명령어들
     program

--- a/src/i18n/locales/en/commands/new.json
+++ b/src/i18n/locales/en/commands/new.json
@@ -25,7 +25,11 @@
     "issue_fetch_failed": "Failed to fetch issue #{{issueNumber}}. The issue may not exist or you may not have access to it.",
     "issues_list_failed": "Failed to fetch issues list. Please enter issue numbers manually.",
     "browser_open_failed": "Failed to open browser to view PR.",
-    "no_github_token_for_pr": "No user authentication token found. PR creation is skipped and only review will proceed. To create a PR, please run autopr init and complete authentication first."
+    "no_github_token_for_pr": "No user authentication token found. PR creation is skipped and only review will proceed. To create a PR, please run autopr init and complete authentication first.",
+    "push_branch_prompt": "Branch does not exist on remote. Would you like to push now?",
+    "push_branch_success": "Branch has been pushed to remote.",
+    "push_branch_cancelled": "Cannot create PR if branch does not exist on remote.",
+    "push_branch_failed": "Failed to push branch to remote: {{error}}"
   },
   "info": {
     "creating": "Creating PR...",
@@ -66,7 +70,8 @@
     "line_by_line_review_comment": "Line-by-line code review",
     "current_branch": "Current branch: {{branch}}",
     "select_base_branch_with_current": "Select target branch for PR (current branch: {{branch}}):",
-    "github_app_required_for_review": "AI review and advanced features are available after GitHub App authentication. Only PR creation will proceed."
+    "github_app_required_for_review": "AI review and advanced features are available after GitHub App authentication. Only PR creation will proceed.",
+    "pr_created_checking_ai_review": "PR has been successfully created. Checking if AI review is available..."
   },
   "prompts": {
     "title": "PR title:",

--- a/src/i18n/locales/ko/commands/new.json
+++ b/src/i18n/locales/ko/commands/new.json
@@ -25,7 +25,11 @@
     "issue_fetch_failed": "이슈 #{{issueNumber}}을(를) 가져오지 못했습니다. 이슈가 존재하지 않거나 접근 권한이 없을 수 있습니다.",
     "issues_list_failed": "이슈 목록을 가져오지 못했습니다. 직접 이슈 번호를 입력해주세요.",
     "browser_open_failed": "PR을 브라우저에서 열지 못했습니다.",
-    "no_github_token_for_pr": "사용자 인증 토큰이 없어 PR 생성이 스킵되고, 리뷰만 진행됩니다. PR 생성을 원하시면 autopr init을 통해 인증을 먼저 진행해 주세요."
+    "no_github_token_for_pr": "사용자 인증 토큰이 없어 PR 생성이 스킵되고, 리뷰만 진행됩니다. PR 생성을 원하시면 autopr init을 통해 인증을 먼저 진행해 주세요.",
+    "push_branch_prompt": "원격 저장소에 브랜치가 없습니다. 지금 push 하시겠습니까?",
+    "push_branch_success": "브랜치가 원격 저장소에 push 되었습니다.",
+    "push_branch_cancelled": "브랜치가 원격 저장소에 없으면 PR을 생성할 수 없습니다.",
+    "push_branch_failed": "브랜치를 원격 저장소에 푸시하지 못했습니다: {{error}}"
   },
   "info": {
     "creating": "PR 생성 중...",
@@ -65,7 +69,8 @@
     "bot_token_acquired": "GitHub App 봇 토큰을 획득했습니다.",
     "line_by_line_review_comment": "라인별 코드 리뷰",
     "current_branch": "현재 브랜치: {{branch}}",
-    "github_app_required_for_review": "AI 리뷰 등 고급 기능은 GitHub App 인증 시 사용 가능합니다. PR 생성만 진행합니다."
+    "github_app_required_for_review": "AI 리뷰 등 고급 기능은 GitHub App 인증 시 사용 가능합니다. PR 생성만 진행합니다.",
+    "pr_created_checking_ai_review": "PR이 성공적으로 생성되었습니다. AI 리뷰 사용 가능 여부를 확인 중입니다..."
   },
   "prompts": {
     "title": "PR 제목:",


### PR DESCRIPTION
# PR 생성 전 브랜치 존재 여부 확인 기능 추가

1. 원격 저장소에 브랜치가 없는 경우, 사용자에게 push 여부를 묻고 push를 수행하는 로직을 추가했습니다.
2. PR 생성 후 AI 리뷰 사용 가능 여부를 확인하는 로직을 추가했습니다.
3. package.json의 버전을 1.0.2로 업데이트했습니다.
4. 관련 국제화(i18n) 텍스트를 추가했습니다.

## 주요 코드 구현사항
- package.json 버전 업데이트 (1.0.1 -> 1.0.2)
- `src/cli/commands/new.ts`에 원격 저장소 브랜치 존재 여부 확인 및 push 로직 추가
- `src/cli/commands/new.ts`에 PR 생성 후 AI 리뷰 확인 로직 추가
- `src/i18n/locales/en/commands/new.json`, `src/i18n/locales/ko/commands/new.json`에 관련 텍스트 추가

## Release Note
별도의 마이그레이션/배포 작업은 필요하지 않습니다.

**Keywords:** PR 생성, 브랜치 push, AI 리뷰, 국제화

> _Reason: 사용자가 원격 저장소에 존재하지 않는 브랜치로 PR을 생성하려고 할 때, 사용자 경험을 개선하고 잠재적인 오류를 방지하기 위해 해당 기능을 추가했습니다._